### PR TITLE
Adding Gossip Support

### DIFF
--- a/adapters/connections/channel_node/policy.rb
+++ b/adapters/connections/channel_node/policy.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Lighstorm
+  module Adapter
+    class Policy
+      def self.get_chan_info(grpc)
+        {
+          fee: {
+            base: { milisatoshis: grpc[:fee_base_msat] },
+            rate: { parts_per_million: grpc[:fee_rate_milli_msat] }
+          },
+          htlc: {
+            minimum: { milisatoshis: grpc[:min_htlc] },
+            maximum: { milisatoshis: grpc[:max_htlc_msat] },
+            # https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection
+            blocks: {
+              delta: {
+                minimum: grpc[:time_lock_delta] # aka cltv_expiry_delta
+              }
+            }
+          }
+        }
+      end
+
+      def self.subscribe_channel_graph(json)
+        result = {
+          _source: :subscribe_channel_graph,
+          fee: {
+            base: { milisatoshis: json['routingPolicy']['feeBaseMsat'].to_i },
+            rate: { parts_per_million: json['routingPolicy']['feeRateMilliMsat'].to_i }
+          },
+          htlc: {
+            minimum: { milisatoshis: json['routingPolicy']['minHtlc'].to_i },
+            maximum: { milisatoshis: json['routingPolicy']['maxHtlcMsat'].to_i },
+            # https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection
+            blocks: {
+              delta: {
+                minimum: json['routingPolicy']['timeLockDelta'].to_i # aka cltv_expiry_delta
+              }
+            }
+          }
+        }
+
+        policy = json['routingPolicy']
+
+        result[:fee].delete(:base) unless policy.key?('feeBaseMsat') && !policy['feeBaseMsat'].nil?
+        result[:fee].delete(:rate) unless policy.key?('feeRateMilliMsat') && !policy['feeRateMilliMsat'].nil?
+        result.delete(:fee) if result[:fee].empty?
+
+        result[:htlc].delete(:minimum) unless policy.key?('minHtlc') && !policy['minHtlc'].nil?
+        result[:htlc].delete(:maximum) unless policy.key?('maxHtlcMsat') && !policy['maxHtlcMsat'].nil?
+        result[:htlc].delete(:blocks) unless policy.key?('timeLockDelta') && !policy['timeLockDelta'].nil?
+        result.delete(:htlc) if result[:htlc].empty?
+
+        return nil unless result.key?(:fee) || result.key?(:htlc)
+
+        result
+      end
+    end
+  end
+end

--- a/adapters/edges/channel.rb
+++ b/adapters/edges/channel.rb
@@ -8,16 +8,16 @@ require_relative '../connections/channel_node'
 module Lighstorm
   module Adapter
     class Channel
-      def self._key(id, active)
+      def self._key(id, state)
         Digest::SHA256.hexdigest(
-          [id, active].join('/')
+          [id, state].join('/')
         )
       end
 
       def self.list_channels(grpc, at)
         {
           _source: :list_channels,
-          _key: _key(grpc[:chan_id], grpc[:active]),
+          _key: _key(grpc[:chan_id], grpc[:active] ? 'active' : 'inactive'),
           # Standard JSON don't support BigInt, so, a String is safer.
           id: grpc[:chan_id].to_s,
           transaction: {
@@ -28,7 +28,7 @@ module Lighstorm
           },
           opened_at: DateTime.parse((at - grpc[:lifetime]).to_s),
           up_at: DateTime.parse((at - grpc[:uptime]).to_s),
-          active: grpc[:active],
+          state: grpc[:active] ? 'active' : 'inactive',
           exposure: grpc[:private] ? 'private' : 'public',
           accounting: {
             capacity: { milisatoshis: grpc[:capacity] * 1000 },
@@ -72,6 +72,23 @@ module Lighstorm
           partners: [
             ChannelNode.describe_graph(grpc, 1),
             ChannelNode.describe_graph(grpc, 2)
+          ]
+        }
+      end
+
+      def self.subscribe_channel_graph(json)
+        {
+          _source: :subscribe_channel_graph,
+          _key: _key(json['chanId'], nil),
+          id: json['chanId'],
+          accounting: {
+            capacity: { milisatoshis: json['capacity'].to_i * 1000 }
+          },
+          partners: [
+            ChannelNode.subscribe_channel_graph(json),
+            { node: {
+              public_key: json['connectingNode']
+            } }
           ]
         }
       end

--- a/adapters/nodes/node.rb
+++ b/adapters/nodes/node.rb
@@ -20,15 +20,19 @@ module Lighstorm
       end
 
       def self.list_channels(grpc, key)
-        {
+        data = {
           _source: :list_channels,
           _key: _key(key == :remote ? grpc[:remote_pubkey] : nil),
           public_key: key == :remote ? grpc[:remote_pubkey] : nil
         }
+
+        return nil if data[:public_key].nil?
+
+        data
       end
 
       def self.get_info(grpc)
-        {
+        data = {
           _source: :get_info,
           _key: _key(grpc[:identity_pubkey]),
           public_key: grpc[:identity_pubkey],
@@ -43,34 +47,64 @@ module Lighstorm
             }
           }
         }
+
+        return nil if data[:public_key].nil? && data[:alias].nil? && data[:color].nil?
+
+        data
       end
 
       def self.get_node_info(grpc)
-        {
+        data = {
           _source: :get_node_info,
           _key: _key(grpc[:node][:pub_key]),
           public_key: grpc[:node][:pub_key],
           alias: grpc[:node][:alias],
           color: grpc[:node][:color]
         }
+
+        return nil if data[:public_key].nil? && data[:alias].nil? && data[:color].nil?
+
+        data
       end
 
       def self.describe_graph(grpc)
-        {
+        data = {
           _source: :describe_graph,
           _key: _key(grpc[:pub_key]),
           public_key: grpc[:pub_key],
           alias: grpc[:alias],
           color: grpc[:color]
         }
+
+        return nil if data[:public_key].nil? && data[:alias].nil? && data[:color].nil?
+
+        data
       end
 
       def self.describe_graph_from_channel(grpc, index)
-        {
+        data = {
           _source: :describe_graph,
           _key: _key(grpc[:"node#{index}_pub"]),
           public_key: grpc[:"node#{index}_pub"]
         }
+
+        return nil if data[:public_key].nil?
+
+        data
+      end
+
+      def self.subscribe_channel_graph(json)
+        data = {
+          _source: :subscribe_channel_graph,
+          _key: _key(json['identityKey']),
+          public_key: json['identityKey'],
+          alias: json['alias'],
+          color: json['color']
+        }
+
+        return nil if data[:public_key].nil? && data[:alias].nil? && data[:color].nil?
+
+        data
       end
     end
   end

--- a/controllers/channel.rb
+++ b/controllers/channel.rb
@@ -18,6 +18,10 @@ module Lighstorm
       def self.find_by_id(id)
         FindById.model(FindById.data(id))
       end
+
+      def self.adapt(dump: nil, gossip: nil)
+        Models::Channel.adapt(dump: dump, gossip: gossip)
+      end
     end
   end
 end

--- a/controllers/channel/actions/apply_gossip.rb
+++ b/controllers/channel/actions/apply_gossip.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+require_relative '../../../ports/grpc'
+require_relative '../../../models/errors'
+require_relative '../../../models/edges/channel'
+require_relative '../../../adapters/edges/channel'
+
+module Lighstorm
+  module Controllers
+    module Channel
+      module ApplyGossip
+        SKIPABLE = [
+          '_key',
+          '_source',
+          'partners/0/_source',
+          'partners/0/policy/_source',
+          'partners/1/_source',
+          'partners/1/policy/_source'
+        ].freeze
+
+        NOT_ALLOWED = [
+          'id'
+        ].freeze
+
+        APPLICABLE = [
+          'accounting/capacity/milisatoshis',
+          'partners/0/policy/fee/base/milisatoshis',
+          'partners/0/state',
+          'partners/1/policy/fee/base/milisatoshis',
+          'partners/1/state',
+          'partners/1/policy/fee/rate/parts_per_million',
+          'partners/0/policy/fee/rate/parts_per_million',
+          'partners/0/policy/htlc/minimum/milisatoshis',
+          'partners/1/policy/htlc/minimum/milisatoshis',
+          'partners/0/policy/htlc/maximum/milisatoshis',
+          'partners/1/policy/htlc/maximum/milisatoshis',
+          'partners/0/policy/htlc/blocks/delta/minimum',
+          'partners/1/policy/htlc/blocks/delta/minimum'
+        ].freeze
+
+        def self.perform(actual, gossip)
+          updated = Models::Channel.new(Adapter::Channel.subscribe_channel_graph(gossip))
+
+          actual_dump = actual.dump
+          updated_dump = updated.dump
+
+          if actual.partners.first.node.public_key == updated.partners.last.node.public_key &&
+             actual.partners.last.node.public_key == updated.partners.first.node.public_key
+            a = updated_dump[:partners][0]
+            b = updated_dump[:partners][1]
+
+            updated_dump[:partners][0] = b
+            updated_dump[:partners][1] = a
+          end
+
+          diff = generate_diff(actual_dump, updated_dump)
+
+          diff.each do |change|
+            key = change[:path].join('/')
+            next unless NOT_ALLOWED.include?(key)
+
+            raise IncoherentGossipError, "Gossip doesn't belong to this Channel"
+          end
+
+          diff.filter do |change|
+            key = change[:path].join('/')
+            if SKIPABLE.include?(key)
+              false
+            elsif APPLICABLE.include?(key)
+              apply!(actual, key, change)
+              true
+            else
+              raise Lighstorm::Errors::MissingGossipHandlerError, "don't know how to apply '#{key}'"
+            end
+          end
+        end
+
+        def self.apply!(actual, key, change)
+          case key
+          when 'accounting/capacity/milisatoshis'
+            token = SecureRandom.hex
+            actual.accounting.prepare_token!(token)
+            actual.accounting.capacity = {
+              value: Models::Satoshis.new(milisatoshis: change[:to]),
+              token: token
+            }
+          when 'partners/0/policy/htlc/maximum/milisatoshis',
+                 'partners/1/policy/htlc/maximum/milisatoshis' then
+            policy = actual.partners[change[:path][1]].policy
+
+            token = SecureRandom.hex
+            policy.htlc.prepare_token!(token)
+            policy.htlc.maximum = {
+              value: Models::Satoshis.new(milisatoshis: change[:to]),
+              token: token
+            }
+          when 'partners/0/policy/htlc/minimum/milisatoshis',
+                 'partners/1/policy/htlc/minimum/milisatoshis' then
+            if actual.partners[change[:path][1]].policy.nil?
+              actual.partners[change[:path][1]].policy = Lighstorm::Models::Policy.new({})
+            end
+
+            policy = actual.partners[change[:path][1]].policy
+
+            token = SecureRandom.hex
+            policy.htlc.prepare_token!(token)
+            policy.htlc.minimum = {
+              value: Models::Satoshis.new(milisatoshis: change[:to]),
+              token: token
+            }
+          when 'partners/0/policy/htlc/blocks/delta/minimum',
+                'partners/1/policy/htlc/blocks/delta/minimum' then
+            if actual.partners[change[:path][1]].policy.nil?
+              actual.partners[change[:path][1]].policy = Lighstorm::Models::Policy.new({})
+            end
+
+            policy = actual.partners[change[:path][1]].policy
+
+            token = SecureRandom.hex
+            policy.htlc.blocks.delta.prepare_token!(token)
+            policy.htlc.blocks.delta.minimum = {
+              value: change[:to],
+              token: token
+            }
+          when 'partners/0/policy/fee/rate/parts_per_million',
+                 'partners/1/policy/fee/rate/parts_per_million' then
+            policy = actual.partners[change[:path][1]].policy
+
+            token = SecureRandom.hex
+            policy.fee.prepare_token!(token)
+            policy.fee.rate = {
+              value: Models::Rate.new(parts_per_million: change[:to]),
+              token: token
+            }
+          when 'partners/0/policy/fee/base/milisatoshis',
+                 'partners/1/policy/fee/base/milisatoshis' then
+            policy = actual.partners[change[:path][1]].policy
+
+            token = SecureRandom.hex
+            policy.fee.prepare_token!(token)
+            policy.fee.base = {
+              value: Models::Satoshis.new(milisatoshis: change[:to]),
+              token: token
+            }
+          when 'partners/0/state',
+               'partners/1/state' then
+            partner = actual.partners[change[:path][1]]
+
+            token = SecureRandom.hex
+            partner.prepare_token!(token)
+            partner.state = { value: change[:to], token: token }
+          else
+            raise Lighstorm::Errors::MissingGossipHandlerError, "don't know how to apply '#{key}'"
+          end
+        end
+
+        def self.generate_diff(actual, node, path = [], diff = [])
+          case node
+          when Hash
+            result = {}
+            node.each_key do |key|
+              result[key] = generate_diff(actual, node[key], path.dup.push(key), diff)
+            end
+          when Array
+            result = []
+            node.each_with_index do |value, i|
+              result << generate_diff(actual, value, path.dup.push(i), diff)
+            end
+          else
+            new_value = node
+
+            unless new_value.nil?
+              actual_value = actual
+              path.each do |key|
+                if actual_value[key]
+                  actual_value = actual_value[key]
+                else
+                  actual_value = nil
+                  break
+                end
+              end
+
+              diff << { path: path, from: actual_value, to: new_value } if actual_value != new_value
+            end
+          end
+
+          diff
+        end
+      end
+    end
+  end
+end

--- a/controllers/channel/find_by_id.rb
+++ b/controllers/channel/find_by_id.rb
@@ -73,7 +73,7 @@ module Lighstorm
         def self.transform(data, adapted)
           [0, 1].each do |i|
             adapted[:list_channels].each_index do |c|
-              if adapted[:list_channels][c][:partners][i][:node][:public_key].nil?
+              if adapted[:list_channels][c][:partners][i][:node].nil?
                 adapted[:list_channels][c][:partners][i][:node] = adapted[:get_info]
               end
             end

--- a/controllers/channel/mine.rb
+++ b/controllers/channel/mine.rb
@@ -63,7 +63,7 @@ module Lighstorm
 
         def self.transform(data, adapted)
           [0, 1].each do |i|
-            data[:partners][i][:node] = adapted[:get_info] if data[:partners][i][:node][:public_key].nil?
+            data[:partners][i][:node] = adapted[:get_info] if data[:partners][i][:node].nil?
 
             adapted[:get_chan_info][data[:id].to_i][:partners].each do |partner|
               if data[:partners][i][:node][:public_key] == partner[:node][:public_key]

--- a/controllers/node.rb
+++ b/controllers/node.rb
@@ -18,6 +18,10 @@ module Lighstorm
       def self.find_by_public_key(public_key)
         FindByPublicKey.model(FindByPublicKey.data(public_key))
       end
+
+      def self.adapt(dump: nil, gossip: nil)
+        Models::Node.adapt(dump: dump, gossip: gossip)
+      end
     end
   end
 end

--- a/controllers/node/actions/apply_gossip.rb
+++ b/controllers/node/actions/apply_gossip.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+require_relative '../../../ports/grpc'
+require_relative '../../../models/errors'
+require_relative '../../../models/nodes/node'
+require_relative '../../../adapters/nodes/node'
+
+module Lighstorm
+  module Controllers
+    module Node
+      module ApplyGossip
+        SKIPABLE = %w[
+          _source
+          _key
+        ].freeze
+
+        NOT_ALLOWED = [
+          'public_key'
+        ].freeze
+
+        APPLICABLE = %w[
+          alias
+          color
+        ].freeze
+
+        def self.perform(actual, gossip)
+          updated = Models::Node.new(Adapter::Node.subscribe_channel_graph(gossip))
+
+          actual_dump = actual.dump
+          updated_dump = updated.dump
+
+          diff = generate_diff(actual_dump, updated_dump)
+
+          diff.each do |change|
+            key = change[:path].join('/')
+            next unless NOT_ALLOWED.include?(key)
+
+            raise IncoherentGossipError, "Gossip doesn't belong to this Node"
+          end
+
+          diff.filter do |change|
+            key = change[:path].join('/')
+            if SKIPABLE.include?(key)
+              false
+            elsif APPLICABLE.include?(key)
+              apply!(actual, key, change)
+              true
+            else
+              raise Lighstorm::Errors::MissingGossipHandlerError, "don't know how to apply '#{key}'"
+            end
+          end
+        end
+
+        def self.apply!(actual, key, change)
+          case key
+          when 'alias'
+            token = SecureRandom.hex
+            actual.prepare_token!(token)
+            actual.alias = {
+              value: change[:to],
+              token: token
+            }
+          when 'color'
+            token = SecureRandom.hex
+            actual.prepare_token!(token)
+            actual.color = {
+              value: change[:to],
+              token: token
+            }
+          else
+            raise Lighstorm::Errors::MissingGossipHandlerError, "don't know how to apply '#{key}'"
+          end
+        end
+
+        def self.generate_diff(actual, node, path = [], diff = [])
+          case node
+          when Hash
+            result = {}
+            node.each_key do |key|
+              result[key] = generate_diff(actual, node[key], path.dup.push(key), diff)
+            end
+          when Array
+            result = []
+            node.each_with_index do |value, i|
+              result << generate_diff(actual, value, path.dup.push(i), diff)
+            end
+          else
+            new_value = node
+
+            unless new_value.nil?
+              actual_value = actual
+              path.each do |key|
+                if actual_value[key]
+                  actual_value = actual_value[key]
+                else
+                  actual_value = nil
+                  break
+                end
+              end
+
+              diff << { path: path, from: actual_value, to: new_value } if actual_value != new_value
+            end
+          end
+
+          diff
+        end
+      end
+    end
+  end
+end

--- a/models/concerns/protectable.rb
+++ b/models/concerns/protectable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Lighstorm
+  module Models
+    module Protectable
+      def prepare_token!(token)
+        @token = token
+      end
+
+      def protect!(value)
+        validate_token!(value)
+      end
+
+      def validate_token!(value)
+        token = value.is_a?(Hash) ? value[:token] : nil
+
+        raise OperationNotAllowedError if token.nil? || @token.nil? || token != @token
+
+        @token = nil
+      end
+    end
+  end
+end

--- a/models/connections/channel_node/accounting.rb
+++ b/models/connections/channel_node/accounting.rb
@@ -16,6 +16,10 @@ module Lighstorm
       def to_h
         { balance: balance.to_h }
       end
+
+      def dump
+        Marshal.load(Marshal.dump(@data))
+      end
     end
   end
 end

--- a/models/connections/channel_node/htlc.rb
+++ b/models/connections/channel_node/htlc.rb
@@ -2,42 +2,48 @@
 
 require_relative '../../satoshis'
 require_relative '../../rate'
-
-require_relative '../../../components/lnd'
+require_relative '../../concerns/protectable'
+require_relative 'htlc/blocks/delta'
 
 module Lighstorm
   module Models
     class HTLC
+      include Protectable
+
       def initialize(data)
         @data = data
       end
 
       def minimum
-        @minimum ||= Satoshis.new(milisatoshis: @data[:minimum][:milisatoshis])
+        @minimum ||= if @data[:minimum]
+                       Satoshis.new(
+                         milisatoshis: @data[:minimum][:milisatoshis]
+                       )
+                     end
       end
 
       def maximum
-        @maximum ||= Satoshis.new(milisatoshis: @data[:maximum][:milisatoshis])
+        @maximum ||= if @data[:maximum]
+                       Satoshis.new(
+                         milisatoshis: @data[:maximum][:milisatoshis]
+                       )
+                     end
       end
 
       def blocks
         @blocks ||= Struct.new(:data) do
           def delta
-            Struct.new(:data) do
-              def minimum
-                data[:minimum]
-              end
+            @delta ||= BlocksDelta.new(data[:delta] || {})
+          end
 
-              def to_h
-                { minimum: minimum }
-              end
-            end.new(data[:delta])
+          def dump
+            { delta: delta.dump }
           end
 
           def to_h
             { delta: delta.to_h }
           end
-        end.new(@data[:blocks])
+        end.new(@data[:blocks] || {})
       end
 
       def to_h
@@ -46,6 +52,34 @@ module Lighstorm
           maximum: maximum.to_h,
           blocks: blocks.to_h
         }
+      end
+
+      def dump
+        result = Marshal.load(Marshal.dump(@data))
+
+        result = result.merge({ blocks: blocks.dump }) if @data[:blocks]
+
+        result
+      end
+
+      def minimum=(value)
+        protect!(value)
+
+        @minimum = value[:value]
+
+        @data[:minimum] = { milisatoshis: @minimum.milisatoshis }
+
+        minimum
+      end
+
+      def maximum=(value)
+        protect!(value)
+
+        @maximum = value[:value]
+
+        @data[:maximum] = { milisatoshis: @maximum.milisatoshis }
+
+        maximum
       end
     end
   end

--- a/models/connections/channel_node/htlc/blocks/delta.rb
+++ b/models/connections/channel_node/htlc/blocks/delta.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../../../concerns/protectable'
+
+module Lighstorm
+  module Models
+    class BlocksDelta
+      include Protectable
+
+      def initialize(data)
+        @data = data
+      end
+
+      def minimum
+        @minimum ||= @data[:minimum]
+      end
+
+      def to_h
+        {
+          minimum: minimum
+        }
+      end
+
+      def dump
+        Marshal.load(Marshal.dump(@data))
+      end
+
+      def minimum=(value)
+        protect!(value)
+
+        @minimum = value[:value]
+
+        @data[:minimum] = @minimum
+
+        minimum
+      end
+    end
+  end
+end

--- a/models/connections/channel_node/policy.rb
+++ b/models/connections/channel_node/policy.rb
@@ -14,15 +14,24 @@ module Lighstorm
       end
 
       def fee
-        @fee ||= @data ? Fee.new(self, @data[:fee]) : nil
+        @fee ||= Fee.new(self, @data ? @data[:fee] : {})
       end
 
       def htlc
-        @htlc ||= @data ? HTLC.new(@data[:htlc]) : nil
+        @htlc ||= HTLC.new(@data ? @data[:htlc] : {})
       end
 
       def to_h
         { fee: fee.to_h, htlc: htlc.to_h }
+      end
+
+      def dump
+        result = Marshal.load(Marshal.dump(@data))
+
+        result = result.merge({ fee: fee.dump }) if @data && @data[:fee]
+        result = result.merge({ htlc: htlc.dump }) if @data && @data[:htlc]
+
+        result
       end
     end
   end

--- a/models/edges/channel/accounting.rb
+++ b/models/edges/channel/accounting.rb
@@ -2,10 +2,13 @@
 
 require_relative '../../satoshis'
 require_relative '../../errors'
+require_relative '../../concerns/protectable'
 
 module Lighstorm
   module Models
     class ChannelAccounting
+      include Protectable
+
       def initialize(data, is_mine)
         @data = data
         @is_mine = is_mine
@@ -62,6 +65,20 @@ module Lighstorm
             capacity: capacity.to_h
           }
         end
+      end
+
+      def dump
+        Marshal.load(Marshal.dump(@data))
+      end
+
+      def capacity=(value)
+        protect!(value)
+
+        @capacity = value[:value]
+
+        @data[:capacity][:milisatoshis] = @capacity.milisatoshis
+
+        capacity
       end
     end
   end

--- a/models/errors.rb
+++ b/models/errors.rb
@@ -6,6 +6,9 @@ module Lighstorm
 
     class ToDoError < LighstormError; end
 
+    class TooManyArgumentsError < LighstormError; end
+    class IncoherentGossipError < LighstormError; end
+    class MissingGossipHandlerError < LighstormError; end
     class MissingCredentialsError < LighstormError; end
     class MissingMilisatoshisError < LighstormError; end
     class MissingPartsPerMillionError < LighstormError; end

--- a/models/nodes/node/lightning.rb
+++ b/models/nodes/node/lightning.rb
@@ -20,6 +20,12 @@ module Lighstorm
           version: version
         }
       end
+
+      def dump
+        Marshal.load(
+          Marshal.dump({ implementation: implementation, version: version })
+        )
+      end
     end
   end
 end

--- a/models/nodes/node/platform.rb
+++ b/models/nodes/node/platform.rb
@@ -37,6 +37,12 @@ module Lighstorm
 
         response
       end
+
+      def dump
+        data = Marshal.load(Marshal.dump(@data))
+        data.merge(lightning: lightning.dump) if @node.myself?
+        data
+      end
     end
   end
 end

--- a/spec/adapters/edges/channel_spec.rb
+++ b/spec/adapters/edges/channel_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 require_relative '../../../adapters/edges/channel'
 require_relative '../../../ports/grpc'
 
@@ -22,9 +24,9 @@ RSpec.describe Lighstorm::Adapter::Channel do
 
       adapted = described_class.list_channels(raw, at)
 
-      Contract.expect!(
+      Contract.expect(
         adapted,
-        '56147059a033801f729c07d1a9e1d5395cc4ec3904356ed379d5bde366cd6dc8'
+        'dc0527ea8fe7648cc3d584ce5e65d6f5eda4540dba4e704314b3b3cebfd4eec0'
       ) do |actual, expected|
         expect(actual.hash).to eq(expected.hash)
         expect(actual.contract).to eq(expected.contract)
@@ -40,6 +42,7 @@ RSpec.describe Lighstorm::Adapter::Channel do
         raw = VCR.replay('lightning.get_chan_info', chan_id: channel_id) do
           Lighstorm::Ports::GRPC.lightning.get_chan_info(chan_id: channel_id).to_h
         end
+
         Contract.expect(
           raw,
           '6435cb37184004825e52beb929c7dd3def4ea690f9b5b17aedbefc3e6fbd21c7'
@@ -59,6 +62,7 @@ RSpec.describe Lighstorm::Adapter::Channel do
                          node: { _source: :get_chan_info,
                                  _key: '3a403058cd81927fe53073367f46d01b0a52bec6705b0ae0d20b5385973c14b0',
                                  public_key: '026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2' },
+                         state: 'active',
                          policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 1 } },
                                    htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 6_237_000_000 },
                                            blocks: { delta: { minimum: 40 } } } } },
@@ -66,6 +70,7 @@ RSpec.describe Lighstorm::Adapter::Channel do
                          node: { _source: :get_chan_info,
                                  _key: '32564df7a5aa5e3fbef3056c77ba6531362478a80c12b0fa32c63f6bd02fde78',
                                  public_key: '02d3c80335a8ccb2ed364c06875f32240f36f7edb37d80f8dbe321b4c364b6e997' },
+                         state: 'active',
                          policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 5 } },
                                    htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 6_045_000_000 },
                                            blocks: { delta: { minimum: 40 } } } } }] }
@@ -100,6 +105,7 @@ RSpec.describe Lighstorm::Adapter::Channel do
                          node: { _source: :get_chan_info,
                                  _key: '3a403058cd81927fe53073367f46d01b0a52bec6705b0ae0d20b5385973c14b0',
                                  public_key: '026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2' },
+                         state: 'active',
                          policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 1 } },
                                    htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 990_000_000 },
                                            blocks: { delta: { minimum: 20 } } } } },
@@ -107,6 +113,7 @@ RSpec.describe Lighstorm::Adapter::Channel do
                          node: { _source: :get_chan_info,
                                  _key: '7aeb224e0e0b4c8d376533e6b102fdaabb0dc5b3ee71658aee96ef80d5c44997',
                                  public_key: '0265e622be131c39ae19e8a9d1195eb509149603f8bf882cd1b8f9707e019b7e7b' },
+                         state: 'active',
                          policy: { fee: { base: { milisatoshis: 1000 }, rate: { parts_per_million: 1 } },
                                    htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 990_000_000 },
                                            blocks: { delta: { minimum: 40 } } } } }] }
@@ -146,6 +153,171 @@ RSpec.describe Lighstorm::Adapter::Channel do
                          node: { _source: :describe_graph,
                                  _key: '9c642c27223c22ca0e265ca357db1abaf6846cace4518cd27a6c22d220b341cd',
                                  public_key: '03c3d14714b78f03fd6ea4997c2b540a4139258249ea1d625c03b68bb82f85d0ea' } }] }
+        )
+      end
+    end
+  end
+
+  context 'subscribe_channel_graph' do
+    context 'complete' do
+      it 'adapts' do
+        channel_id = 837_471_618_647_916_545
+
+        reference_raw = VCR.replay('lightning.get_chan_info', chan_id: channel_id) do
+          Lighstorm::Ports::GRPC.lightning.get_chan_info(chan_id: channel_id).to_h
+        end
+
+        Contract.expect(
+          reference_raw,
+          '6435cb37184004825e52beb929c7dd3def4ea690f9b5b17aedbefc3e6fbd21c7'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+        end
+
+        reference_adapted = described_class.get_chan_info(reference_raw)
+
+        expect(reference_adapted).to eq(
+          { _source: :get_chan_info,
+            _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: { capacity: { milisatoshis: 5_000_000_000 } },
+            partners: [{ _source: :get_chan_info,
+                         node: { _source: :get_chan_info,
+                                 _key: 'de2939d174ddd01e051a5b05e3e2e40479d0dfd16ee5295c0b4985890a603ffc',
+                                 public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7' },
+                         state: 'active',
+                         policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 700 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 4_950_000_000 },
+                                           blocks: { delta: { minimum: 40 } } } } },
+                       { _source: :get_chan_info,
+                         node: { _source: :get_chan_info,
+                                 _key: '713519e5aca513a070deedc0520be905e0fc3e36f555c33f977b6c369b7d76fb',
+                                 public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba' },
+                         state: 'active',
+                         policy: { fee: { base: { milisatoshis: 1000 }, rate: { parts_per_million: 300 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 4_950_000_000 },
+                                           blocks: { delta: { minimum: 144 } } } } }] }
+        )
+
+        raw = JSON.parse(File.read('spec/data/gossip/channel/sample-a.json'))
+
+        Contract.expect(
+          raw,
+          'b653933617b1a914b6f5ad22b9469fed69b7f8a7107de113e0cea263a05575c0'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+        end
+
+        adapted = described_class.subscribe_channel_graph(raw)
+
+        expect(adapted).to eq(
+          { _source: :subscribe_channel_graph,
+            _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: { capacity: { milisatoshis: 5_000_000_000 } },
+            partners: [{ _source: :subscribe_channel_graph,
+                         node: { public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba' },
+                         policy: { _source: :subscribe_channel_graph,
+                                   fee: { base: { milisatoshis: 1000 }, rate: { parts_per_million: 300 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 4_950_000_000 },
+                                           blocks: { delta: { minimum: 144 } } } } },
+                       { node: { public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7' } }] }
+        )
+      end
+    end
+
+    context 'missing fields' do
+      it 'adapts' do
+        channel_id = 798_835_879_549_927_425
+
+        reference_raw = VCR.replay('lightning.get_chan_info', chan_id: channel_id) do
+          Lighstorm::Ports::GRPC.lightning.get_chan_info(chan_id: channel_id).to_h
+        end
+
+        Contract.expect(
+          reference_raw,
+          '6435cb37184004825e52beb929c7dd3def4ea690f9b5b17aedbefc3e6fbd21c7'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+        end
+
+        reference_adapted = described_class.get_chan_info(reference_raw)
+
+        expect(reference_adapted).to eq(
+          { _source: :get_chan_info,
+            _key: 'd81f408d0cfeac62db4c2d11bbad13d9c4370ffbdca6c1053a50c38560129735',
+            id: '798835879549927425',
+            accounting: { capacity: { milisatoshis: 400_000_000 } },
+            partners: [{ _source: :get_chan_info,
+                         node: { _source: :get_chan_info,
+                                 _key: '88e2a6fc09e5abe81b7d23e69a471e5bc0940be89c3b3d2de809121da6d5e34e',
+                                 public_key: '0207ed361128e101a16605fd8e7b491e2d28f7db1677363c9712a3907523a414d2' },
+                         state: 'active',
+                         policy: { fee: { base: { milisatoshis: 100 }, rate: { parts_per_million: 0 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 396_000_000 },
+                                           blocks: { delta: { minimum: 40 } } } } },
+                       { _source: :get_chan_info,
+                         node: { _source: :get_chan_info,
+                                 _key: '3a403058cd81927fe53073367f46d01b0a52bec6705b0ae0d20b5385973c14b0',
+                                 public_key: '026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2' },
+                         state: 'active',
+                         policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 1 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 396_000_000 },
+                                           blocks: { delta: { minimum: 20 } } } } }] }
+        )
+
+        raw = JSON.parse(File.read('spec/data/gossip/channel/sample-b.json'))
+
+        Contract.expect(
+          raw,
+          '9c8fb3a4aac7b4cc94c965043cf5fd1f6111707be315a905279fb5d6b3c598b8'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+        end
+
+        adapted = described_class.subscribe_channel_graph(raw)
+
+        expect(adapted).to eq(
+          { _source: :subscribe_channel_graph,
+            _key: 'd81f408d0cfeac62db4c2d11bbad13d9c4370ffbdca6c1053a50c38560129735',
+            id: '798835879549927425',
+            accounting: { capacity: { milisatoshis: 400_000_000 } },
+            partners: [{ _source: :subscribe_channel_graph,
+                         node: { public_key: '0207ed361128e101a16605fd8e7b491e2d28f7db1677363c9712a3907523a414d2' },
+                         policy: { _source: :subscribe_channel_graph,
+                                   fee: { base: { milisatoshis: 150 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 396_000_000 },
+                                           blocks: { delta: { minimum: 40 } } } } },
+                       { node: { public_key: '026165850492521f4ac8abd9bd8088123446d126f648ca35e60f88177dc149ceb2' } }] }
+        )
+      end
+    end
+
+    context 'inactive' do
+      it 'adapts' do
+        raw = JSON.parse(File.read('spec/data/gossip/channel/sample-c.json'))
+
+        Contract.expect(
+          raw,
+          '758dffdec71b227fbed3fa30c1ed44db5a01387de7de3433c65126f30c5943f8'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+        end
+
+        adapted = described_class.subscribe_channel_graph(raw)
+
+        expect(adapted).to eq(
+          { _source: :subscribe_channel_graph,
+            _key: '31268bb02f9536cb951e4c2f7785e4c6e04274f59d6e9c18315f6a6d3725c685',
+            id: '838301749944647681',
+            accounting: { capacity: { milisatoshis: 350_000_000 } },
+            partners: [{ _source: :subscribe_channel_graph, node: { public_key: '023ad453e0ab3767112427b654247bbdd337864532d38967485ab622d05f5d26db' }, state: 'inactive' },
+                       { node: { public_key: '03055d3f08f9bf7725dc0644192f045e3466995db33c7464b0e32fb3542d866b87' } }] }
         )
       end
     end

--- a/spec/adapters/nodes/node_spec.rb
+++ b/spec/adapters/nodes/node_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 require_relative '../../../adapters/nodes/node'
 require_relative '../../../ports/grpc'
 
@@ -190,6 +192,30 @@ RSpec.describe Lighstorm::Adapter::Node do
             color: '#000000' }
         )
       end
+    end
+  end
+
+  context 'subscribe_channel_graph' do
+    it 'adapts' do
+      raw = JSON.parse(File.read('spec/data/gossip/node/sample-a.json'))
+
+      Contract.expect(
+        raw,
+        '4c2391f8606f0b8da3c846fe510dd1202a9cfd9df5f7523583c54b55c1026a5b'
+      ) do |actual, expected|
+        expect(actual.hash).to eq(expected.hash)
+        expect(actual.contract).to eq(expected.contract)
+      end
+
+      adapted = described_class.subscribe_channel_graph(raw)
+
+      expect(adapted).to eq(
+        { _source: :subscribe_channel_graph,
+          _key: '8b8b460416bc384260ca166233827f361a0c0da7b632c68a2720e08fbe3f528c',
+          public_key: '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b',
+          alias: 'SampleNode',
+          color: '#ff5002' }
+      )
     end
   end
 end

--- a/spec/controllers/channel/actions/apply_gossip_spec.rb
+++ b/spec/controllers/channel/actions/apply_gossip_spec.rb
@@ -1,0 +1,382 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../../controllers/channel/find_by_id'
+
+require_relative '../../../../models/edges/channel'
+
+require_relative '../../../../ports/dsl/lighstorm/errors'
+
+RSpec.describe Lighstorm::Models::Channel do
+  describe '.apply!' do
+    let(:channel) do
+      data = Lighstorm::Controllers::Channel::FindById.data(channel_id) do |fetch|
+        VCR.replay("Controllers::Channel.find_by_id/#{channel_id}") { fetch.call }
+      end
+
+      described_class.new(data)
+    end
+
+    context 'complete without changes A' do
+      let(:channel_id) { 837_471_618_647_916_545 }
+
+      it 'applies the gossip' do
+        previous_dump = channel.dump
+
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-a.json'))
+
+        diff = channel.apply!(gossip: gossip)
+
+        expect(diff).to eq([])
+
+        expect(channel.dump).to eq(previous_dump)
+      end
+    end
+
+    context 'complete with changes error B' do
+      let(:channel_id) { 837_471_618_647_916_545 }
+
+      it 'applies the gossip' do
+        previous_dump = channel.dump
+
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-b.json'))
+
+        expect { channel.apply!(gossip: gossip) }.to raise_error(
+          IncoherentGossipError, "Gossip doesn't belong to this Channel"
+        )
+      end
+    end
+
+    context 'complete with changes B' do
+      let(:channel_id) { 798_835_879_549_927_425 }
+
+      it 'applies the gossip' do
+        previous_to_h = channel.to_h
+        previous_dump = channel.dump
+
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-b.json'))
+
+        expect(channel.partners[0].policy.fee.base.milisatoshis).not_to eq(150)
+
+        diff = channel.apply!(gossip: gossip)
+
+        expect(channel.partners[0].policy.fee.base.milisatoshis).to eq(150)
+
+        expect(diff).to eq(
+          [{ from: 100, path: [:partners, 0, :policy, :fee, :base, :milisatoshis], to: 150 }]
+        )
+
+        expect(channel.to_h).not_to eq(previous_to_h)
+        expect(channel.dump).not_to eq(previous_dump)
+      end
+    end
+
+    context 'complete with changes C' do
+      let(:channel_id) { 838_301_749_944_647_681 }
+
+      it 'applies the gossip' do
+        previous_to_h = channel.to_h
+        previous_dump = channel.dump
+
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-c.json'))
+
+        expect(channel.partners[0].state).not_to eq('inactive')
+
+        diff = channel.apply!(gossip: gossip)
+
+        expect(channel.partners[0].state).to eq('inactive')
+
+        expect(diff).to eq(
+          [{ from: 'active', path: [:partners, 0, :state], to: 'inactive' }]
+        )
+
+        expect(channel.to_h).not_to eq(previous_to_h)
+        expect(channel.dump).not_to eq(previous_dump)
+      end
+    end
+
+    context 'all fields D' do
+      let(:channel_id) { 837_471_618_647_916_545 }
+
+      it 'applies the gossip' do
+        previous_to_h = channel.to_h
+        previous_dump = channel.dump
+
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-d.json'))
+
+        expect(previous_to_h).to eq(
+          { _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: { capacity: { milisatoshis: 5_000_000_000 } },
+            partners: [
+              { state: 'active',
+                node: {
+                  _key: 'de2939d174ddd01e051a5b05e3e2e40479d0dfd16ee5295c0b4985890a603ffc',
+                  public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7',
+                  alias: 'SatoshiIsProudOfUs',
+                  color: '#fa770f',
+                  platform: { blockchain: 'bitcoin', network: 'mainnet' }
+                },
+                policy: {
+                  fee: {
+                    base: { milisatoshis: 0 },
+                    rate: { parts_per_million: 700 }
+                  },
+                  htlc: {
+                    minimum: { milisatoshis: 1000 },
+                    maximum: { milisatoshis: 4_950_000_000 },
+                    blocks: { delta: { minimum: 40 } }
+                  }
+                } },
+              { state: 'active',
+                node: {
+                  _key: '713519e5aca513a070deedc0520be905e0fc3e36f555c33f977b6c369b7d76fb',
+                  public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba',
+                  alias: 'ln.nicehash.com [Nicehash]',
+                  color: '#cf1b99',
+                  platform: { blockchain: 'bitcoin', network: 'mainnet' }
+                },
+                policy: {
+                  fee: {
+                    base: { milisatoshis: 1000 },
+                    rate: { parts_per_million: 300 }
+                  },
+                  htlc: {
+                    minimum: { milisatoshis: 1000 },
+                    maximum: { milisatoshis: 4_950_000_000 },
+                    blocks: { delta: { minimum: 144 } }
+                  }
+                } }
+            ] }
+        )
+
+        expect(previous_dump).to eq(
+          { _source: :get_chan_info,
+            _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: { capacity: { milisatoshis: 5_000_000_000 } },
+            partners: [
+              { _source: :get_chan_info,
+                node: {
+                  _source: :get_node_info,
+                  _key: 'de2939d174ddd01e051a5b05e3e2e40479d0dfd16ee5295c0b4985890a603ffc',
+                  public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7',
+                  alias: 'SatoshiIsProudOfUs',
+                  color: '#fa770f',
+                  platform: { blockchain: 'bitcoin', network: 'mainnet' },
+                  myself: false
+                },
+                state: 'active',
+                policy: {
+                  fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 700 } },
+                  htlc: {
+                    minimum: { milisatoshis: 1000 },
+                    maximum: { milisatoshis: 4_950_000_000 },
+                    blocks: { delta: { minimum: 40 } }
+                  }
+                } },
+              { _source: :get_chan_info,
+                node: {
+                  _source: :get_node_info,
+                  _key: '713519e5aca513a070deedc0520be905e0fc3e36f555c33f977b6c369b7d76fb',
+                  public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba',
+                  alias: 'ln.nicehash.com [Nicehash]',
+                  color: '#cf1b99',
+                  platform: { blockchain: 'bitcoin', network: 'mainnet' },
+                  myself: false
+                },
+                state: 'active',
+                policy: {
+                  fee: { base: { milisatoshis: 1000 },
+                         rate: { parts_per_million: 300 } },
+                  htlc: {
+                    minimum: { milisatoshis: 1000 },
+                    maximum: { milisatoshis: 4_950_000_000 },
+                    blocks: { delta: { minimum: 144 } }
+                  }
+                } }
+            ],
+            known: true,
+            mine: false,
+            exposure: 'public' }
+        )
+
+        expect(channel.accounting.capacity.milisatoshis).not_to eq(6_000_000_000)
+
+        expect(channel.partners[1].state).not_to eq('inactive')
+
+        expect(channel.partners[1].policy.fee.base.milisatoshis).not_to eq(1700)
+        expect(channel.partners[1].policy.fee.rate.parts_per_million).not_to eq(800)
+
+        expect(channel.partners[1].policy.htlc.maximum.milisatoshis).not_to eq(5_950_000_000)
+        expect(channel.partners[1].policy.htlc.minimum.milisatoshis).not_to eq(1400)
+        expect(channel.partners[1].policy.htlc.blocks.delta.minimum).not_to eq(200)
+
+        diff = channel.apply!(gossip: gossip)
+
+        expect(channel.accounting.capacity.milisatoshis).to eq(6_000_000_000)
+
+        expect(channel.partners[1].state).to eq('inactive')
+
+        expect(channel.partners[1].policy.fee.base.milisatoshis).to eq(1700)
+        expect(channel.partners[1].policy.fee.rate.parts_per_million).to eq(800)
+
+        expect(channel.partners[1].policy.htlc.maximum.milisatoshis).to eq(5_950_000_000)
+        expect(channel.partners[1].policy.htlc.minimum.milisatoshis).to eq(1400)
+        expect(channel.partners[1].policy.htlc.blocks.delta.minimum).to eq(200)
+
+        expect(diff).to eq(
+          [{
+            path: %i[accounting capacity milisatoshis],
+            from: 5_000_000_000, to: 6_000_000_000
+          },
+           {
+             path: [:partners, 1, :policy, :fee, :base, :milisatoshis],
+             from: 1000, to: 1700
+           },
+           {
+             path: [:partners, 1, :policy, :fee, :rate, :parts_per_million],
+             from: 300, to: 800
+           },
+           {
+             path: [:partners, 1, :policy, :htlc, :minimum, :milisatoshis],
+             from: 1000, to: 1400
+           },
+           { path: [:partners, 1, :policy, :htlc, :maximum, :milisatoshis],
+             from: 4_950_000_000, to: 5_950_000_000 },
+           {
+             path: [:partners, 1, :policy, :htlc, :blocks, :delta, :minimum],
+             from: 144, to: 200
+           },
+           {
+             path: [:partners, 1, :state],
+             from: 'active', to: 'inactive'
+           }]
+        )
+
+        expect(channel.to_h).not_to eq(previous_to_h)
+        expect(channel.dump).not_to eq(previous_dump)
+
+        expect(channel.to_h).to eq(
+          { _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: { capacity: { milisatoshis: 6_000_000_000 } },
+            partners: [{ state: 'active',
+                         node: { _key: 'de2939d174ddd01e051a5b05e3e2e40479d0dfd16ee5295c0b4985890a603ffc',
+                                 public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7',
+                                 alias: 'SatoshiIsProudOfUs',
+                                 color: '#fa770f',
+                                 platform: { blockchain: 'bitcoin', network: 'mainnet' } },
+                         policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 700 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 4_950_000_000 },
+                                           blocks: { delta: { minimum: 40 } } } } },
+                       { state: 'inactive',
+                         node: { _key: '713519e5aca513a070deedc0520be905e0fc3e36f555c33f977b6c369b7d76fb',
+                                 public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba',
+                                 alias: 'ln.nicehash.com [Nicehash]',
+                                 color: '#cf1b99',
+                                 platform: { blockchain: 'bitcoin', network: 'mainnet' } },
+                         policy: { fee: { base: { milisatoshis: 1700 }, rate: { parts_per_million: 800 } },
+                                   htlc: { minimum: { milisatoshis: 1400 }, maximum: { milisatoshis: 5_950_000_000 },
+                                           blocks: { delta: { minimum: 200 } } } } }] }
+        )
+
+        expect(channel.dump).to eq(
+          { _source: :get_chan_info,
+            _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: { capacity: { milisatoshis: 6_000_000_000 } },
+            partners: [{ _source: :get_chan_info,
+                         node: { _source: :get_node_info,
+                                 _key: 'de2939d174ddd01e051a5b05e3e2e40479d0dfd16ee5295c0b4985890a603ffc',
+                                 public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7',
+                                 alias: 'SatoshiIsProudOfUs',
+                                 color: '#fa770f',
+                                 platform: { blockchain: 'bitcoin', network: 'mainnet' },
+                                 myself: false },
+                         state: 'active',
+                         policy: { fee: { base: { milisatoshis: 0 }, rate: { parts_per_million: 700 } },
+                                   htlc: { minimum: { milisatoshis: 1000 }, maximum: { milisatoshis: 4_950_000_000 },
+                                           blocks: { delta: { minimum: 40 } } } } },
+                       { _source: :get_chan_info,
+                         node: { _source: :get_node_info,
+                                 _key: '713519e5aca513a070deedc0520be905e0fc3e36f555c33f977b6c369b7d76fb',
+                                 public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba',
+                                 alias: 'ln.nicehash.com [Nicehash]',
+                                 color: '#cf1b99',
+                                 platform: { blockchain: 'bitcoin', network: 'mainnet' },
+                                 myself: false },
+                         state: 'inactive',
+                         policy: { fee: { base: { milisatoshis: 1700 }, rate: { parts_per_million: 800 } },
+                                   htlc: { minimum: { milisatoshis: 1400 }, maximum: { milisatoshis: 5_950_000_000 },
+                                           blocks: { delta: { minimum: 200 } } } } }],
+            known: true,
+            mine: false,
+            exposure: 'public' }
+        )
+      end
+    end
+
+    context 'from empty' do
+      it 'applies the gossip' do
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-d.json'))
+
+        channel = described_class.adapt(gossip: gossip)
+
+        expect(channel.to_h).to eq(
+          { _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            partners: [
+              { state: 'inactive',
+                node: { _key: nil,
+                        public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba' },
+                policy: {
+                  fee: {
+                    base: { milisatoshis: 1700 },
+                    rate: { parts_per_million: 800 }
+                  },
+                  htlc: {
+                    minimum: { milisatoshis: 1400 },
+                    maximum: { milisatoshis: 5_950_000_000 },
+                    blocks: { delta: { minimum: 200 } }
+                  }
+                } },
+              { state: nil,
+                node: { _key: nil,
+                        public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7' } }
+            ] }
+        )
+
+        expect(channel.dump).to eq(
+          { _source: :subscribe_channel_graph,
+            _key: '36c34f134dd6b41c4bb9c8a84e90e6903d9fff663af6cfe2ea68acdca5660f46',
+            id: '837471618647916545',
+            accounting: {
+              capacity: { milisatoshis: 6_000_000_000 }
+            },
+            partners: [
+              { _source: :subscribe_channel_graph,
+                node: { public_key: '037659a0ac8eb3b8d0a720114efc861d3a940382dcfa1403746b4f8f6b2e8810ba' },
+                policy: {
+                  _source: :subscribe_channel_graph,
+                  fee: {
+                    base: { milisatoshis: 1700 },
+                    rate: { parts_per_million: 800 }
+                  },
+                  htlc: {
+                    minimum: { milisatoshis: 1400 },
+                    maximum: { milisatoshis: 5_950_000_000 },
+                    blocks: { delta: { minimum: 200 } }
+                  }
+                },
+                state: 'inactive' },
+              { node: { public_key: '0201af659a3986832bb5bf2493c537cee9f7d62a7bff5d0a68176c1d60df931cf7' } }
+            ] }
+        )
+
+        expect { channel.apply!(gossip: gossip) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/controllers/node/actions/apply_gossip_spec.rb
+++ b/spec/controllers/node/actions/apply_gossip_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../../controllers/node/find_by_public_key'
+
+require_relative '../../../../models/nodes/node'
+
+require_relative '../../../../ports/dsl/lighstorm/errors'
+
+RSpec.describe Lighstorm::Models::Node do
+  describe '.apply!' do
+    let(:node) do
+      data = Lighstorm::Controllers::Node::FindByPublicKey.data(public_key) do |fetch|
+        VCR.replay("Controllers::Node.find_by_public_key/#{public_key}") { fetch.call }
+      end
+
+      described_class.new(data)
+    end
+
+    context 'complete with changes' do
+      let(:public_key) { '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b' }
+
+      it 'applies the gossip' do
+        previous_to_h = node.to_h
+        previous_dump = node.dump
+
+        expect(previous_to_h).to eq(
+          { _key: '8b8b460416bc384260ca166233827f361a0c0da7b632c68a2720e08fbe3f528c',
+            public_key: '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b',
+            alias: 'Gerdtrudroepke',
+            color: '#ff5000',
+            platform: { blockchain: 'bitcoin', network: 'mainnet' } }
+        )
+
+        expect(previous_dump).to eq(
+          { _source: :get_node_info,
+            _key: '8b8b460416bc384260ca166233827f361a0c0da7b632c68a2720e08fbe3f528c',
+            public_key: '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b',
+            alias: 'Gerdtrudroepke',
+            color: '#ff5000',
+            platform: { blockchain: 'bitcoin', network: 'mainnet' },
+            myself: false }
+        )
+
+        gossip = JSON.parse(File.read('spec/data/gossip/node/sample-a.json'))
+
+        expect(node.alias).not_to eq('SampleNode')
+        expect(node.color).not_to eq('#ff5002')
+
+        diff = node.apply!(gossip: gossip)
+
+        expect(node.alias).to eq('SampleNode')
+        expect(node.color).to eq('#ff5002')
+
+        expect(diff).to eq(
+          [{ path: [:alias], from: 'Gerdtrudroepke', to: 'SampleNode' },
+           { path: [:color], from: '#ff5000', to: '#ff5002' }]
+        )
+
+        expect(node.to_h).not_to eq(previous_to_h)
+        expect(node.dump).not_to eq(previous_dump)
+      end
+    end
+
+    context 'from empty' do
+      it 'applies the gossip' do
+        gossip = JSON.parse(File.read('spec/data/gossip/node/sample-a.json'))
+
+        node = described_class.adapt(gossip: gossip)
+
+        expect(node.to_h).to eq(
+          { _key: '8b8b460416bc384260ca166233827f361a0c0da7b632c68a2720e08fbe3f528c',
+            public_key: '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b',
+            alias: 'SampleNode',
+            color: '#ff5002' }
+        )
+
+        expect(node.dump).to eq(
+          { _source: :subscribe_channel_graph,
+            _key: '8b8b460416bc384260ca166233827f361a0c0da7b632c68a2720e08fbe3f528c',
+            public_key: '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b',
+            alias: 'SampleNode',
+            color: '#ff5002' }
+        )
+
+        expect { node.apply!(gossip: gossip) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/helpers/contract.rb
+++ b/spec/helpers/contract.rb
@@ -6,11 +6,13 @@ require 'digest'
 require 'fileutils'
 
 module Contract
+  GENERATE = false
+
   def self.expect!(actual_data, expected_hash, &block)
     expect(actual_data, expected_hash, generate: true, &block)
   end
 
-  def self.expect(actual_data, expected_hash, generate: false, &block)
+  def self.expect(actual_data, expected_hash, generate: GENERATE, &block)
     actual_contract = generate(actual_data)
     actual_hash = hash(actual_contract, save_to_disk: generate)
 

--- a/spec/helpers/contract_spec.rb
+++ b/spec/helpers/contract_spec.rb
@@ -3,6 +3,12 @@
 require 'date'
 
 RSpec.describe Contract do
+  describe 'generate' do
+    it 'avoid unexpected config' do
+      expect(Contract::GENERATE).to be(false)
+    end
+  end
+
   describe 'contract_type' do
     it 'generates type' do
       expect(described_class.contract_type(nil)).to eq('Nil')

--- a/spec/helpers/sanitizer/safe.rb
+++ b/spec/helpers/sanitizer/safe.rb
@@ -2,8 +2,6 @@
 
 module Sanitizer
   SAFE = {
-    'time_lock_delta <= node1_policy' => true,
-    'time_lock_delta <= node2_policy' => true,
     'accept_time <= htlcs' => true,
     'active <= list_channels' => true,
     'active' => true,
@@ -74,6 +72,8 @@ module Sanitizer
     'description_hash <= list_invoices' => true,
     'description_hash <= lookup_invoice' => true,
     'description_hash' => true,
+    'disabled <= node1_policy' => true,
+    'disabled <= node2_policy' => true,
     'expiry <= decode_pay_req' => true,
     'expiry <= hops' => true,
     'expiry <= list_invoices' => true,
@@ -167,6 +167,8 @@ module Sanitizer
     'status <= htlcs' => true,
     'status <= list_payments' => true,
     'status' => true,
+    'time_lock_delta <= node1_policy' => true,
+    'time_lock_delta <= node2_policy' => true,
     'timestamp <= decode_pay_req' => true,
     'timestamp <= forwarding_history' => true,
     'timestamp' => true,

--- a/spec/helpers/sanitizer/unsafe.rb
+++ b/spec/helpers/sanitizer/unsafe.rb
@@ -47,8 +47,6 @@ module Sanitizer
     'day_fee_sum <= fee_report' => true,
     'destination <= decode_pay_req' => true,
     'destination' => true,
-    'disabled <= node1_policy' => true,
-    'disabled <= node2_policy' => true,
     'dust_limit_sat <= local_constraints' => true,
     'dust_limit_sat <= remote_constraints' => true,
     'expiration_height <= pending_htlcs' => true,

--- a/spec/integration/dsl/channel_spec.rb
+++ b/spec/integration/dsl/channel_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Integration Tests' do
           expect(Contract.for(channel.id)).to eq('String:11..20')
           expect(Contract.for(channel.opened_at)).to eq('DateTime')
           expect(Contract.for(channel.up_at)).to eq('DateTime')
-          expect(Contract.for(channel.active)).to eq('Boolean')
+          expect(Contract.for(channel.state)).to eq('String:0..10')
+          expect(Contract.for(channel.active?)).to eq('Boolean')
           expect(Contract.for(channel.exposure)).to eq('String:0..10')
 
           expect(Contract.for(channel.transaction.funding.id)).to eq('String:50+')
@@ -75,7 +76,8 @@ RSpec.describe 'Integration Tests' do
 
           expect { channel.opened_at }.to raise_error(NotYourChannelError)
           expect { channel.up_at }.to raise_error(NotYourChannelError)
-          expect { channel.active }.to raise_error(NotYourChannelError)
+          expect { channel.state }.to raise_error(NotYourChannelError)
+          expect { channel.active? }.to raise_error(NotYourChannelError)
 
           expect(Contract.for(channel.exposure)).to eq('String:0..10')
 
@@ -95,42 +97,46 @@ RSpec.describe 'Integration Tests' do
 
           expect(Contract.for(channel.partners[0].node.public_key)).to eq('String:50+')
 
-          expect(Contract.for(channel.partners[0].policy.fee)).to eq('Nil')
-          expect(Contract.for(channel.partners[0].policy.htlc)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.fee.base)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.fee.rate)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.htlc.minimum)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.htlc.maximum)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.htlc.blocks.delta.minimum)).to eq('Nil')
 
           expect { channel.partners[1].accounting }.to raise_error(NotYourChannelError)
           expect(channel.partners[1].node.myself?).to be(false)
 
           expect(Contract.for(channel.partners[1].node.public_key)).to eq('String:50+')
 
-          expect(Contract.for(channel.partners[1].policy.fee)).to eq('Nil')
-          expect(Contract.for(channel.partners[1].policy.htlc)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.fee.base)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.fee.rate)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.htlc.minimum)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.htlc.maximum)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.htlc.blocks.delta.minimum)).to eq('Nil')
 
           expect(Contract.for(channel.to_h)).to eq(
             { _key: 'String:50+',
-              accounting: { capacity: { milisatoshis: 'Integer:0..10' } },
+              accounting: {
+                capacity: { milisatoshis: 'Integer:0..10' }
+              },
               id: 'String:11..20',
               partners: [
                 { node: {
-                  _key: 'String:50+',
-                  alias: 'String:0..10',
-                  color: 'String:0..10',
-                  platform: {
-                    blockchain: 'String:0..10',
-                    network: 'String:0..10'
+                    _key: 'String:50+',
+                    alias: 'String:0..10',
+                    color: 'String:0..10',
+                    platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                    public_key: 'String:50+'
                   },
-                  public_key: 'String:50+'
-                } },
+                  state: 'Nil' },
                 { node: {
-                  _key: 'String:50+',
-                  alias: 'String:0..10',
-                  color: 'String:0..10',
-                  platform: {
-                    blockchain: 'String:0..10',
-                    network: 'String:0..10'
+                    _key: 'String:50+',
+                    alias: 'String:0..10',
+                    color: 'String:0..10',
+                    platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                    public_key: 'String:50+'
                   },
-                  public_key: 'String:50+'
-                } }
+                  state: 'Nil' }
               ] }
           )
         end
@@ -160,7 +166,8 @@ RSpec.describe 'Integration Tests' do
 
           expect { channel.opened_at }.to raise_error(NotYourChannelError)
           expect { channel.up_at }.to raise_error(NotYourChannelError)
-          expect { channel.active }.to raise_error(NotYourChannelError)
+          expect { channel.state }.to raise_error(NotYourChannelError)
+          expect { channel.active? }.to raise_error(NotYourChannelError)
 
           expect(Contract.for(channel.exposure)).to eq('String:0..10')
 
@@ -180,16 +187,22 @@ RSpec.describe 'Integration Tests' do
 
           expect(Contract.for(channel.partners[0].node.public_key)).to eq('String:50+')
 
-          expect(Contract.for(channel.partners[0].policy.fee)).to eq('Nil')
-          expect(Contract.for(channel.partners[0].policy.htlc)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.fee.base)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.fee.rate)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.htlc.minimum)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.htlc.maximum)).to eq('Nil')
+          expect(Contract.for(channel.partners[0].policy.htlc.blocks.delta.minimum)).to eq('Nil')
 
           expect { channel.partners[1].accounting }.to raise_error(NotYourChannelError)
           expect(channel.partners[1].node.myself?).to be(false)
 
           expect(Contract.for(channel.partners[1].node.public_key)).to eq('String:50+')
 
-          expect(Contract.for(channel.partners[1].policy.fee)).to eq('Nil')
-          expect(Contract.for(channel.partners[1].policy.htlc)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.fee.base)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.fee.rate)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.htlc.minimum)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.htlc.maximum)).to eq('Nil')
+          expect(Contract.for(channel.partners[1].policy.htlc.blocks.delta.minimum)).to eq('Nil')
 
           expect(Contract.for(channel.to_h)).to eq(
             { _key: 'String:50+',
@@ -197,15 +210,19 @@ RSpec.describe 'Integration Tests' do
               id: 'String:11..20',
               partners: [
                 { node: {
-                  _key: 'String:50+',
-                  platform: { blockchain: 'String:0..10', network: 'String:0..10' },
-                  public_key: 'String:50+'
-                } },
-                { node: {
-                  _key: 'String:50+',
-                  platform: { blockchain: 'String:0..10', network: 'String:0..10' },
-                  public_key: 'String:50+'
-                } }
+                    _key: 'String:50+',
+                    platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                    public_key: 'String:50+'
+                  },
+                  state: 'Nil' },
+                {
+                  node: {
+                    _key: 'String:50+',
+                    platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                    public_key: 'String:50+'
+                  },
+                  state: 'Nil'
+                }
               ] }
           )
         end

--- a/spec/models/edges/channel/dump_spec.rb
+++ b/spec/models/edges/channel/dump_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../../controllers/channel/mine'
+require_relative '../../../../controllers/channel/all'
+require_relative '../../../../controllers/channel/find_by_id'
+require_relative '../../../../adapters/edges/channel'
+
+require_relative '../../../../models/edges/channel'
+
+require_relative '../../../../ports/dsl/lighstorm/errors'
+
+RSpec.describe Lighstorm::Models::Channel do
+  describe '.dump' do
+    context 'popular' do
+      it 'provides data portability' do
+        channel_id = '853996178921881601'
+
+        data = Lighstorm::Controllers::Channel::FindById.data(channel_id) do |fetch|
+          VCR.replay("Controllers::Channel.find_by_id/#{channel_id}") { fetch.call }
+        end
+
+        channel = described_class.new(data)
+
+        Contract.expect(
+          channel.dump, '511cbdca8d6e4e775614e856e1c77f0756a6f3d45f78f11da056643da590aff7'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:11..20',
+              accounting: { capacity: { milisatoshis: 'Integer:11..20' } },
+              exposure: 'String:0..10',
+              id: 'String:11..20',
+              known: 'Boolean',
+              mine: 'Boolean',
+              partners: [
+                { _source: 'Symbol:11..20',
+                  node: {
+                    _key: 'String:50+',
+                    _source: 'Symbol:11..20',
+                    alias: 'String:11..20',
+                    color: 'String:0..10',
+                    myself: 'Boolean',
+                    platform: {
+                      blockchain: 'String:0..10',
+                      network: 'String:0..10'
+                    },
+                    public_key: 'String:50+'
+                  },
+                  policy: {
+                    fee: {
+                      base: { milisatoshis: 'Integer:0..10' },
+                      rate: { parts_per_million: 'Integer:0..10' }
+                    },
+                    htlc: {
+                      blocks: { delta: { minimum: 'Integer:0..10' } },
+                      maximum: { milisatoshis: 'Integer:11..20' },
+                      minimum: { milisatoshis: 'Integer:0..10' }
+                    }
+                  },
+                  state: 'String:0..10' },
+                { _source: 'Symbol:11..20',
+                  node: {
+                    _key: 'String:50+',
+                    _source: 'Symbol:11..20',
+                    alias: 'String:11..20',
+                    color: 'String:0..10',
+                    myself: 'Boolean',
+                    platform: {
+                      blockchain: 'String:0..10',
+                      network: 'String:0..10'
+                    },
+                    public_key: 'String:50+'
+                  },
+                  policy: {
+                    fee: {
+                      base: { milisatoshis: 'Integer:0..10' },
+                      rate: { parts_per_million: 'Integer:0..10' }
+                    },
+                    htlc: {
+                      blocks: { delta: { minimum: 'Integer:0..10' } },
+                      maximum: { milisatoshis: 'Integer:11..20' },
+                      minimum: { milisatoshis: 'Integer:0..10' }
+                    }
+                  },
+                  state: 'String:0..10' }
+              ] }
+          )
+        end
+
+        expect(channel.dump).to eq(described_class.new(channel.dump).dump)
+        expect(channel.to_h).to eq(described_class.new(channel.dump).to_h)
+      end
+    end
+
+    context 'mine' do
+      it 'models' do
+        data = Lighstorm::Controllers::Channel::Mine.data do |fetch|
+          VCR.replay('Controllers::Channel.mine') do
+            data = fetch.call
+            data[:list_channels] = [data[:list_channels][0].to_h]
+            data
+          end
+        end
+
+        channel = described_class.new(data[0])
+
+        Contract.expect(
+          channel.dump, '9f8c0a6458464c0bd746bbfec6f3975c1bbbee687d4f1d67792a9eefd2b45fb3'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:11..20',
+              accounting: {
+                capacity: { milisatoshis: 'Integer:0..10' },
+                received: { milisatoshis: 'Integer:11..20' },
+                sent: { milisatoshis: 'Integer:11..20' },
+                unsettled: { milisatoshis: 'Integer:0..10' }
+              },
+              exposure: 'String:0..10',
+              id: 'String:11..20',
+              known: 'Boolean',
+              mine: 'Boolean',
+              opened_at: 'DateTime',
+              partners: [
+                { _source: 'Symbol:11..20',
+                  accounting: { balance: { milisatoshis: 'Integer:0..10' } },
+                  node: {
+                    _key: 'String:50+',
+                    _source: 'Symbol:0..10',
+                    alias: 'String:11..20',
+                    color: 'String:0..10',
+                    myself: 'Boolean',
+                    platform: {
+                      blockchain: 'String:0..10',
+                      lightning: { implementation: 'String:0..10', version: 'String:31..40' },
+                      network: 'String:0..10'
+                    },
+                    public_key: 'String:50+'
+                  },
+                  policy: {
+                    fee: {
+                      base: { milisatoshis: 'Integer:0..10' },
+                      rate: { parts_per_million: 'Integer:0..10' }
+                    },
+                    htlc: {
+                      blocks: { delta: { minimum: 'Integer:0..10' } },
+                      maximum: { milisatoshis: 'Integer:0..10' },
+                      minimum: { milisatoshis: 'Integer:0..10' }
+                    }
+                  },
+                  state: 'String:0..10' },
+                { _source: 'Symbol:11..20',
+                  accounting: { balance: { milisatoshis: 'Integer:0..10' } },
+                  node: {
+                    _key: 'String:50+',
+                    _source: 'Symbol:11..20',
+                    alias: 'String:11..20',
+                    color: 'String:0..10',
+                    myself: 'Boolean',
+                    platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                    public_key: 'String:50+'
+                  },
+                  policy: {
+                    fee: {
+                      base: { milisatoshis: 'Integer:0..10' },
+                      rate: { parts_per_million: 'Integer:0..10' }
+                    },
+                    htlc: {
+                      blocks: { delta: { minimum: 'Integer:0..10' } },
+                      maximum: { milisatoshis: 'Integer:0..10' },
+                      minimum: { milisatoshis: 'Integer:0..10' }
+                    }
+                  },
+                  state: 'String:0..10' }
+              ],
+              state: 'String:0..10',
+              transaction: { funding: { id: 'String:50+', index: 'Integer:0..10' } },
+              up_at: 'DateTime' }
+          )
+        end
+
+        expect(channel.dump).to eq(described_class.new(channel.dump).dump)
+        expect(channel.to_h).to eq(described_class.new(channel.dump).to_h)
+
+        params = {
+          rate: { parts_per_million: channel.myself.policy.fee.rate.parts_per_million + 5 },
+          base: { milisatoshis: channel.myself.policy.fee.base.milisatoshis + 7 }
+        }
+
+        channel.myself.policy.fee.update(params, preview: false, fake: true)
+
+        expect(channel.myself.policy.fee.rate.parts_per_million).to eq(
+          params[:rate][:parts_per_million]
+        )
+
+        expect(channel.myself.policy.fee.base.milisatoshis).to eq(
+          params[:base][:milisatoshis]
+        )
+
+        copy = described_class.new(channel.dump)
+
+        expect(copy.myself.policy.fee.rate.parts_per_million).to eq(
+          params[:rate][:parts_per_million]
+        )
+
+        expect(copy.myself.policy.fee.base.milisatoshis).to eq(
+          params[:base][:milisatoshis]
+        )
+      end
+    end
+
+    context 'gossip B' do
+      it 'provides data portability' do
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-b.json'))
+
+        channel = described_class.new(
+          Lighstorm::Adapter::Channel.subscribe_channel_graph(gossip)
+        )
+
+        Contract.expect(
+          channel.dump, '978f0502508630bdef70857130fb02009550a614ea7c68b8010d6407c9de733e'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:21..30',
+              accounting: { capacity: { milisatoshis: 'Integer:0..10' } },
+              id: 'String:11..20',
+              partners: [
+                { _source: 'Symbol:21..30',
+                  node: { public_key: 'String:50+' },
+                  policy: {
+                    _source: 'Symbol:21..30',
+                    fee: {
+                      base: { milisatoshis: 'Integer:0..10' }
+                    },
+                    htlc: {
+                      blocks: { delta: { minimum: 'Integer:0..10' } },
+                      maximum: { milisatoshis: 'Integer:0..10' },
+                      minimum: { milisatoshis: 'Integer:0..10' }
+                    }
+                  } },
+                { node: { public_key: 'String:50+' } }
+              ] }
+          )
+        end
+
+        expect(channel.dump).to eq(described_class.new(channel.dump).dump)
+        expect(channel.to_h).to eq(described_class.new(channel.dump).to_h)
+      end
+    end
+
+    context 'gossip A' do
+      it 'provides data portability' do
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-a.json'))
+
+        channel = described_class.new(
+          Lighstorm::Adapter::Channel.subscribe_channel_graph(gossip)
+        )
+
+        Contract.expect(
+          channel.dump, '741ae62ea22b48af83bef17336bf101755cc82c2f656882be0d098bf900e6de4'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:21..30',
+              accounting: { capacity: { milisatoshis: 'Integer:0..10' } },
+              id: 'String:11..20',
+              partners: [{ _source: 'Symbol:21..30',
+                           node: { public_key: 'String:50+' },
+                           policy: { _source: 'Symbol:21..30',
+                                     fee: { base: { milisatoshis: 'Integer:0..10' },
+                                            rate: { parts_per_million: 'Integer:0..10' } },
+                                     htlc: { blocks: { delta: { minimum: 'Integer:0..10' } }, maximum: { milisatoshis: 'Integer:0..10' },
+                                             minimum: { milisatoshis: 'Integer:0..10' } } } },
+                         { node: { public_key: 'String:50+' } }] }
+          )
+        end
+
+        expect(channel.dump).to eq(described_class.new(channel.dump).dump)
+        expect(channel.to_h).to eq(described_class.new(channel.dump).to_h)
+      end
+    end
+
+    context 'gossip C' do
+      it 'provides data portability' do
+        gossip = JSON.parse(File.read('spec/data/gossip/channel/sample-c.json'))
+
+        channel = described_class.new(
+          Lighstorm::Adapter::Channel.subscribe_channel_graph(gossip)
+        )
+
+        Contract.expect(
+          channel.dump, 'c4de9f110925bcd4186d9f624c9cf87488c7acf171f6d3b7c16bb9f4f8eb1146'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:21..30',
+              accounting: { capacity: { milisatoshis: 'Integer:0..10' } },
+              id: 'String:11..20',
+              partners: [{ _source: 'Symbol:21..30', node: { public_key: 'String:50+' }, state: 'String:0..10' },
+                         { node: { public_key: 'String:50+' } }] }
+          )
+        end
+
+        expect(channel.dump).to eq(described_class.new(channel.dump).dump)
+        expect(channel.to_h).to eq(described_class.new(channel.dump).to_h)
+      end
+    end
+  end
+end

--- a/spec/models/edges/channel/gossip_spec.rb
+++ b/spec/models/edges/channel/gossip_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../../models/edges/channel'
+
+RSpec.describe Lighstorm::Models::Channel do
+  context 'error' do
+    it 'raises error' do
+      expect { described_class.adapt }.to raise_error(
+        ArgumentError, 'missing gossip: or dump:'
+      )
+
+      expect { described_class.adapt(gossip: {}, dump: {}) }.to raise_error(
+        TooManyArgumentsError, 'you need to pass gossip: or dump:, not both'
+      )
+    end
+  end
+
+  describe '.apply!' do
+    let(:dump) { symbolize_keys(JSON.parse(File.read("spec/data/gossip/channel/#{hash}/dump.json"))) }
+    let(:gossip) { JSON.parse(File.read("spec/data/gossip/channel/#{hash}/gossip.json")) }
+
+    context '29f0873593ae' do
+      let(:hash) { '29f0873593ae' }
+
+      it 'provides data portability' do
+        channel = described_class.adapt(dump: dump)
+        diff = channel.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          [{ path: [:partners, 1, :policy, :fee, :rate, :parts_per_million], from: 100, to: 150 },
+           { path: [:partners, 1, :policy, :htlc, :minimum, :milisatoshis], from: 1000, to: 1200 },
+           { path: [:partners, 1, :policy, :htlc, :maximum, :milisatoshis], from: 990_000_000,
+             to: 920_000_000 },
+           { path: [:partners, 1, :policy, :htlc, :blocks, :delta, :minimum], from: 40, to: 20 }]
+        )
+      end
+    end
+
+    context '367d90b62389' do
+      let(:hash) { '367d90b62389' }
+
+      it 'provides data portability' do
+        channel = described_class.adapt(gossip: gossip)
+
+        expect(channel.to_h).to eq(
+          { _key: 'd727f0e4ecfd1a468a554a6f329e7c568a76999cf2a55d3cae231ec716537ed4',
+            id: '766802707818938369',
+            partners: [{ state: nil,
+                         node: { _key: nil,
+                                 public_key: '03d5099461761b1b4d3f3d2edfe9c929c71ad384ac18abe58a7188890964c8390a' },
+                         policy: { fee: { rate: { parts_per_million: 150 } },
+                                   htlc: { minimum: { milisatoshis: 1200 }, maximum: { milisatoshis: 920_000_000 },
+                                           blocks: { delta: { minimum: 20 } } } } },
+                       { state: nil,
+                         node: { _key: nil,
+                                 public_key: '02170ffa14bc0486252ad0213e698570cb5492955f6f6cd5ab97145a94e11ae696' } }] }
+        )
+      end
+    end
+
+    context '6506965fedda' do
+      let(:hash) { '6506965fedda' }
+
+      it 'provides data portability' do
+        channel = described_class.adapt(dump: dump)
+        diff = channel.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          [{ path: [:partners, 0, :policy, :fee, :base, :milisatoshis], from: nil, to: 2_147_483_647 },
+           { path: [:partners, 0, :policy, :fee, :rate, :parts_per_million], from: nil, to: 2_147_483_647 },
+           { path: [:partners, 0, :policy, :htlc, :minimum, :milisatoshis], from: nil, to: 1 },
+           { path: [:partners, 0, :policy, :htlc, :maximum, :milisatoshis], from: nil, to: 15_093_000_000 },
+           { path: [:partners, 0, :policy, :htlc, :blocks, :delta, :minimum], from: nil, to: 72 },
+           { path: [:partners, 0, :state], from: nil, to: 'inactive' }]
+        )
+      end
+    end
+
+    context '8bb2503d3072' do
+      let(:hash) { '8bb2503d3072' }
+
+      it 'provides data portability' do
+        channel = described_class.adapt(dump: dump)
+        diff = channel.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          [{ path: [:partners, 1, :policy, :fee, :rate, :parts_per_million], from: 100, to: 150 },
+           { path: [:partners, 1, :policy, :htlc, :minimum, :milisatoshis], from: 1000, to: 1200 },
+           { path: [:partners, 1, :policy, :htlc, :maximum, :milisatoshis], from: 990_000_000,
+             to: 920_000_000 },
+           { path: [:partners, 1, :policy, :htlc, :blocks, :delta, :minimum], from: 40, to: 20 }]
+        )
+      end
+    end
+
+    context 'f328a264e336' do
+      let(:hash) { 'f328a264e336' }
+
+      it 'provides data portability' do
+        channel = described_class.adapt(dump: dump)
+        diff = channel.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          [{ path: [:partners, 0, :policy, :htlc, :minimum, :milisatoshis], from: nil, to: 1000 },
+           { path: [:partners, 0, :policy, :htlc, :maximum, :milisatoshis], from: nil, to: 396_000_000 },
+           { path: [:partners, 0, :policy, :htlc, :blocks, :delta, :minimum], from: nil, to: 144 }]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/edges/channel_spec.rb
+++ b/spec/models/edges/channel_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Lighstorm::Models::Channel do
       expect(channel.up_at).to be_a(DateTime)
       expect(channel.up_at).to be > channel.opened_at
       expect(channel.up_at.to_s.size).to eq(25)
-      expect(channel.active).to be(true)
+      expect(channel.state).to be('active')
+      expect(channel.active?).to be(true)
       expect(channel.exposure).to eq('public')
 
       expect(channel.transaction.funding.id.class).to eq(String)
@@ -145,7 +146,7 @@ RSpec.describe Lighstorm::Models::Channel do
       )
 
       Contract.expect(
-        channel.to_h, '68766c3c3d1e2ac98062cd88bebf513aa35f9a5731246c0a0c6e4a9547788fef'
+        channel.to_h, '727cfffebcc4a3cb627aa8b3eacb04c932215caf217220873887e502bdfd38cf'
       ) do |actual, expected|
         expect(actual.hash).to eq(expected.hash)
         expect(actual.contract).to eq(expected.contract)
@@ -175,7 +176,8 @@ RSpec.describe Lighstorm::Models::Channel do
         expect(channel.opened_at.to_s.size).to eq(25)
         expect(channel.up_at).to be_a(DateTime)
         expect(channel.up_at.to_s.size).to eq(25)
-        expect(channel.active).to be(true)
+        expect(channel.state).to be('active')
+        expect(channel.active?).to be(true)
         expect(channel.exposure).to eq('public')
 
         expect(channel.accounting.capacity.milisatoshis).to eq(6_200_000_000)
@@ -280,7 +282,7 @@ RSpec.describe Lighstorm::Models::Channel do
         )
 
         Contract.expect(
-          channel.to_h, '68766c3c3d1e2ac98062cd88bebf513aa35f9a5731246c0a0c6e4a9547788fef'
+          channel.to_h, '727cfffebcc4a3cb627aa8b3eacb04c932215caf217220873887e502bdfd38cf'
         ) do |actual, expected|
           expect(actual.hash).to eq(expected.hash)
           expect(actual.contract).to eq(expected.contract)
@@ -306,7 +308,8 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.opened_at }.to raise_error(NotYourChannelError)
         expect { channel.up_at }.to raise_error(NotYourChannelError)
-        expect { channel.active }.to raise_error(NotYourChannelError)
+        expect { channel.state }.to raise_error(NotYourChannelError)
+        expect { channel.active? }.to raise_error(NotYourChannelError)
 
         expect(channel.exposure).to eq('public')
 
@@ -327,8 +330,11 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.partners[0].accounting }.to raise_error(NotYourChannelError)
 
-        expect(channel.partners[0].policy.fee).to be_nil
-        expect(channel.partners[0].policy.htlc).to be_nil
+        expect(channel.partners[0].policy.fee.base).to be_nil
+        expect(channel.partners[0].policy.fee.rate).to be_nil
+        expect(channel.partners[0].policy.htlc.minimum).to be_nil
+        expect(channel.partners[0].policy.htlc.maximum).to be_nil
+        expect(channel.partners[0].policy.htlc.blocks.delta.minimum).to be_nil
         expect(channel.partners[0].node.platform.blockchain).to eq('bitcoin')
         expect(channel.partners[0].node.platform.network).to eq('mainnet')
 
@@ -344,8 +350,11 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.partners[1].accounting }.to raise_error(NotYourChannelError)
 
-        expect(channel.partners[1].policy.fee).to be_nil
-        expect(channel.partners[1].policy.htlc).to be_nil
+        expect(channel.partners[1].policy.fee.base).to be_nil
+        expect(channel.partners[1].policy.fee.rate).to be_nil
+        expect(channel.partners[1].policy.htlc.minimum).to be_nil
+        expect(channel.partners[1].policy.htlc.maximum).to be_nil
+        expect(channel.partners[1].policy.htlc.blocks.delta.minimum).to be_nil
 
         expect(channel.partners[1].node.platform.blockchain).to eq('bitcoin')
         expect(channel.partners[1].node.platform.network).to eq('mainnet')
@@ -353,7 +362,7 @@ RSpec.describe Lighstorm::Models::Channel do
         expect { channel.partners[1].node.platform.lightning }.to raise_error(NotYourNodeError)
 
         Contract.expect(
-          channel.to_h, 'b12045f9300c1894db3a42e624d062b20c3b02b71e3a31e0f2ac32eaa89d66c3'
+          channel.to_h, '05f7283abe9bbb861f4e0c56aa0d45bd49ee3164123412f375d115c833327d70'
         ) do |actual, expected|
           expect(actual.hash).to eq(expected.hash)
           expect(actual.contract).to eq(expected.contract)
@@ -379,7 +388,8 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.opened_at }.to raise_error(NotYourChannelError)
         expect { channel.up_at }.to raise_error(NotYourChannelError)
-        expect { channel.active }.to raise_error(NotYourChannelError)
+        expect { channel.state }.to raise_error(NotYourChannelError)
+        expect { channel.active? }.to raise_error(NotYourChannelError)
 
         expect(channel.exposure).to eq('public')
 
@@ -446,7 +456,7 @@ RSpec.describe Lighstorm::Models::Channel do
         expect { channel.partners[1].node.platform.lightning }.to raise_error(NotYourNodeError)
 
         Contract.expect(
-          channel.to_h, '66cb139e20123723491f8fc3d6a5029d1c2887cbf7c99a264ad0c7894bf1267c'
+          channel.to_h, '168edbce05294fb68511b986c7b0da7f85045928b426c3731d18011455e76b90'
         ) do |actual, expected|
           expect(actual.hash).to eq(expected.hash)
           expect(actual.contract).to eq(expected.contract)
@@ -485,7 +495,8 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.opened_at }.to raise_error(NotYourChannelError)
         expect { channel.up_at }.to raise_error(NotYourChannelError)
-        expect { channel.active }.to raise_error(NotYourChannelError)
+        expect { channel.state }.to raise_error(NotYourChannelError)
+        expect { channel.active? }.to raise_error(NotYourChannelError)
 
         expect(channel.exposure).to eq('public')
 
@@ -505,8 +516,11 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.partners[0].accounting }.to raise_error(NotYourChannelError)
 
-        expect(channel.partners[0].policy.fee).to be_nil
-        expect(channel.partners[0].policy.htlc).to be_nil
+        expect(channel.partners[0].policy.fee.base).to be_nil
+        expect(channel.partners[0].policy.fee.rate).to be_nil
+        expect(channel.partners[0].policy.htlc.minimum).to be_nil
+        expect(channel.partners[0].policy.htlc.maximum).to be_nil
+        expect(channel.partners[0].policy.htlc.blocks.delta.minimum).to be_nil
 
         expect(channel.partners[0].node.platform.blockchain).to eq('bitcoin')
         expect(channel.partners[0].node.platform.network).to eq('mainnet')
@@ -526,8 +540,11 @@ RSpec.describe Lighstorm::Models::Channel do
 
         expect { channel.partners[1].accounting }.to raise_error(NotYourChannelError)
 
-        expect(channel.partners[1].policy.fee).to be_nil
-        expect(channel.partners[1].policy.htlc).to be_nil
+        expect(channel.partners[1].policy.fee.base).to be_nil
+        expect(channel.partners[1].policy.fee.rate).to be_nil
+        expect(channel.partners[1].policy.htlc.minimum).to be_nil
+        expect(channel.partners[1].policy.htlc.maximum).to be_nil
+        expect(channel.partners[1].policy.htlc.blocks.delta.minimum).to be_nil
 
         expect(channel.partners[1].node.platform.blockchain).to eq('bitcoin')
         expect(channel.partners[1].node.platform.network).to eq('mainnet')
@@ -535,7 +552,7 @@ RSpec.describe Lighstorm::Models::Channel do
         expect { channel.partners[1].node.platform.lightning }.to raise_error(NotYourNodeError)
 
         Contract.expect(
-          channel.to_h, '7c818c1a0aefee3fb3a2765804a2f3eecb363202c210571bcf7444d7ea21aacd'
+          channel.to_h, 'db4d187e10fdf9461f0a6818ec78787f0bd9f5675e344ad785ff1293eac3e8e3'
         ) do |actual, expected|
           expect(actual.hash).to eq(expected.hash)
           expect(actual.contract).to eq(expected.contract)
@@ -557,7 +574,8 @@ RSpec.describe Lighstorm::Models::Channel do
         expect(channel.opened_at.to_s.size).to eq(25)
         expect(channel.up_at).to be_a(DateTime)
         expect(channel.up_at.to_s.size).to eq(25)
-        expect(channel.active).to be(true)
+        expect(channel.state).to eq('active')
+        expect(channel.active?).to be(true)
         expect(channel.exposure).to eq('public')
 
         expect(channel.accounting.capacity.milisatoshis).to eq(6_500_000_000)
@@ -650,7 +668,7 @@ RSpec.describe Lighstorm::Models::Channel do
         expect { channel.partners[1].node.platform.lightning }.to raise_error(NotYourNodeError)
 
         Contract.expect(
-          channel.to_h, '14d7ea0645d1cf9282e6715019bb55117256505b0b9acfd23f8e2de6e5d30c78'
+          channel.to_h, '21df298a1220ec2d5dbeeb545d02b7676a8bb0fb9f7d2312dcf620b11cb808dc'
         ) do |actual, expected|
           expect(actual.hash).to eq(expected.hash)
           expect(actual.contract).to eq(expected.contract)

--- a/spec/models/edges/forward/group_spec.rb
+++ b/spec/models/edges/forward/group_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe Lighstorm::Models::ChannelForwardsGroup do
           expect(group.channel.up_at).to be_a(DateTime)
           expect(group.channel.up_at.to_s.size).to eq(25)
           expect(group.channel.up_at).to be > group.channel.opened_at
-          expect(group.channel.active).to be(true)
+          expect(group.channel.state).to be('active')
+          expect(group.channel.active?).to be(true)
           expect(group.channel.exposure).to eq('public')
 
           expect(group.channel.accounting.capacity.milisatoshis).to eq(6_200_000_000)
@@ -111,7 +112,7 @@ RSpec.describe Lighstorm::Models::ChannelForwardsGroup do
           )
 
           Contract.expect(
-            group.to_h, '1ae33175b0a6e2e748b08cbcd765ff632749ac5ed33459ee63af283283f2afa7'
+            group.to_h, '3d35f885c6592b8c49607e13be7727a68c6eb96030770c1db2ff7e40c4f3680f'
           ) do |actual, expected|
             expect(actual.hash).to eq(expected.hash)
             expect(actual.contract).to eq(expected.contract)
@@ -150,7 +151,8 @@ RSpec.describe Lighstorm::Models::ChannelForwardsGroup do
           expect { group.channel.mine? }.to raise_error(UnknownChannelError)
           expect { group.channel.opened_at }.to raise_error(UnknownChannelError)
           expect { group.channel.up_at }.to raise_error(UnknownChannelError)
-          expect { group.channel.active }.to raise_error(UnknownChannelError)
+          expect { group.channel.state }.to raise_error(UnknownChannelError)
+          expect { group.channel.active? }.to raise_error(UnknownChannelError)
           expect { group.channel.exposure }.to raise_error(UnknownChannelError)
           expect { group.channel.accounting }.to raise_error(UnknownChannelError)
           expect { group.channel.myself }.to raise_error(UnknownChannelError)

--- a/spec/models/edges/forward_spec.rb
+++ b/spec/models/edges/forward_spec.rb
@@ -61,15 +61,16 @@ RSpec.describe Lighstorm::Models::Forward do
         expect(forward.in.channel.up_at).to be_a(DateTime)
         expect(forward.in.channel.up_at.to_s.size).to eq(25)
         expect(forward.in.channel.up_at).to be > forward.in.channel.opened_at
-        expect(forward.in.channel.active).to be(true)
+        expect(forward.in.channel.state).to be('active')
+        expect(forward.in.channel.active?).to be(true)
         expect(forward.in.channel.exposure).to eq('public')
 
         expect(forward.in.channel.accounting.capacity.milisatoshis).to eq(6_300_000_000)
         expect(forward.in.channel.accounting.capacity.satoshis).to eq(6_300_000)
         expect(forward.in.channel.accounting.sent.milisatoshis).to eq(49_124_312_000)
         expect(forward.in.channel.accounting.sent.satoshis).to eq(49_124_312)
-        expect(forward.in.channel.accounting.received.milisatoshis).to eq(45_861_996_000)
-        expect(forward.in.channel.accounting.received.satoshis).to eq(45_861_996)
+        expect(forward.in.channel.accounting.received.milisatoshis).to be > 45_000_000_000
+        expect(forward.in.channel.accounting.received.satoshis).to be > 45_000_000
         expect(forward.in.channel.accounting.unsettled.milisatoshis).to eq(0)
         expect(forward.in.channel.accounting.unsettled.satoshis).to eq(0)
 
@@ -131,7 +132,8 @@ RSpec.describe Lighstorm::Models::Forward do
         expect(forward.out.channel.up_at).to be_a(DateTime)
         expect(forward.out.channel.up_at.to_s.size).to eq(25)
         expect(forward.out.channel.up_at).to be > forward.out.channel.opened_at
-        expect(forward.out.channel.active).to be(true)
+        expect(forward.out.channel.state).to be('active')
+        expect(forward.out.channel.active?).to be(true)
         expect(forward.out.channel.exposure).to eq('public')
 
         expect(forward.out.channel.accounting.capacity.milisatoshis).to eq(6_500_000_000)
@@ -195,7 +197,7 @@ RSpec.describe Lighstorm::Models::Forward do
 
         Contract.expect(
           forward.to_h,
-          'c1be274121a04ba3432b796df049f5d0c5caff079800f2992c2ed63308f21dd0'
+          '6a176182716537a27e16ccac679f5b9f8d1c6e1b63bb089a040740e8925d5a64'
         ) do |actual, expected|
           expect(actual.hash).to eq(expected.hash)
           expect(actual.contract).to eq(expected.contract)
@@ -252,7 +254,8 @@ RSpec.describe Lighstorm::Models::Forward do
         expect { forward.in.channel.mine? }.to raise_error(UnknownChannelError)
         expect { forward.in.channel.opened_at }.to raise_error(UnknownChannelError)
         expect { forward.in.channel.up_at }.to raise_error(UnknownChannelError)
-        expect { forward.in.channel.active }.to raise_error(UnknownChannelError)
+        expect { forward.in.channel.state }.to raise_error(UnknownChannelError)
+        expect { forward.in.channel.active? }.to raise_error(UnknownChannelError)
         expect { forward.in.channel.exposure }.to raise_error(UnknownChannelError)
         expect { forward.in.channel.accounting }.to raise_error(UnknownChannelError)
         expect { forward.in.channel.myself }.to raise_error(UnknownChannelError)
@@ -268,7 +271,8 @@ RSpec.describe Lighstorm::Models::Forward do
         expect { forward.out.channel.mine? }.to raise_error(UnknownChannelError)
         expect { forward.out.channel.opened_at }.to raise_error(UnknownChannelError)
         expect { forward.out.channel.up_at }.to raise_error(UnknownChannelError)
-        expect { forward.out.channel.active }.to raise_error(UnknownChannelError)
+        expect { forward.out.channel.state }.to raise_error(UnknownChannelError)
+        expect { forward.out.channel.active? }.to raise_error(UnknownChannelError)
         expect { forward.out.channel.exposure }.to raise_error(UnknownChannelError)
         expect { forward.out.channel.accounting }.to raise_error(UnknownChannelError)
         expect { forward.out.channel.myself }.to raise_error(UnknownChannelError)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Lighstorm::Models::Invoice do
       expect(invoice.request.secret.preimage.size).to eq(64)
       expect(invoice.request.secret.hash).to eq('7dc0a651f241c5c940ae303338e96af942b7559009728e2ab046d8f6583419ba')
 
-      Contract.expect!(
+      Contract.expect(
         invoice.to_h, '45241f7af3c82af35d58160759453041b17dc91643b113ff7e712ab2f69f78fd'
       ) do |actual, expected|
         expect(actual.hash).to eq(expected.hash)

--- a/spec/models/nodes/node/dump_spec.rb
+++ b/spec/models/nodes/node/dump_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../../controllers/node/myself'
+require_relative '../../../../controllers/node/find_by_public_key'
+require_relative '../../../../controllers/node/all'
+
+require_relative '../../../../models/nodes/node'
+
+require_relative '../../../../ports/dsl/lighstorm/errors'
+
+RSpec.describe Lighstorm::Models::Node do
+  describe '.dump' do
+    context 'samples' do
+      let(:data) do
+        myself = Lighstorm::Controllers::Node::Myself.data do |fetch|
+          VCR.replay('Controllers::Node.myself') { fetch.call }
+        end
+
+        data = Lighstorm::Controllers::Node::All.data do |fetch|
+          VCR.replay('Controllers::Node.all/samples') do
+            data = fetch.call
+
+            data[:describe_graph] = [
+              data[:describe_graph].find { |n| n.alias != '' && n.pub_key != myself[:public_key] },
+              data[:describe_graph].find { |n| n.alias == '' && n.pub_key != myself[:public_key] },
+              data[:describe_graph].find { |n| n.pub_key == myself[:public_key] }
+            ].map(&:to_h)
+
+            data
+          end
+        end
+      end
+
+      it 'provides data portability' do
+        node_alias = described_class.new(data[0])
+        node_no_alias = described_class.new(data[1])
+        node_myself = described_class.new(data[2])
+
+        Contract.expect(
+          node_alias.dump, 'dd336ce8879b3461a2c4d0402f43467731f1464f9c4a6b207a41f140c7a810b4'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:11..20',
+              alias: 'String:0..10',
+              color: 'String:0..10',
+              myself: 'Boolean',
+              platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+              public_key: 'String:50+' }
+          )
+        end
+
+        Contract.expect(
+          node_no_alias.dump, 'dd336ce8879b3461a2c4d0402f43467731f1464f9c4a6b207a41f140c7a810b4'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:11..20',
+              alias: 'String:0..10',
+              color: 'String:0..10',
+              myself: 'Boolean',
+              platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+              public_key: 'String:50+' }
+          )
+        end
+
+        Contract.expect(
+          node_myself.dump, '1106bdab8aa3864249b00dd9c74329ed36e88365fa9e04fafbf8ce714dde5aa7'
+        ) do |actual, expected|
+          expect(actual.hash).to eq(expected.hash)
+          expect(actual.contract).to eq(expected.contract)
+
+          expect(actual.contract).to eq(
+            { _key: 'String:50+',
+              _source: 'Symbol:0..10',
+              alias: 'String:11..20',
+              color: 'String:0..10',
+              myself: 'Boolean',
+              platform: {
+                blockchain: 'String:0..10',
+                lightning: {
+                  implementation: 'String:0..10',
+                  version: 'String:31..40'
+                },
+                network: 'String:0..10'
+              },
+              public_key: 'String:50+' }
+          )
+        end
+
+        expect(node_alias.dump).to eq(described_class.new(node_alias.dump).dump)
+        expect(node_no_alias.dump).to eq(described_class.new(node_no_alias.dump).dump)
+        expect(node_myself.dump).to eq(described_class.new(node_myself.dump).dump)
+
+        expect(node_alias.to_h).to eq(described_class.new(node_alias.dump).to_h)
+        expect(node_no_alias.to_h).to eq(described_class.new(node_no_alias.dump).to_h)
+        expect(node_myself.to_h).to eq(described_class.new(node_myself.dump).to_h)
+      end
+    end
+  end
+end

--- a/spec/models/nodes/node/gossip_spec.rb
+++ b/spec/models/nodes/node/gossip_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../../models/nodes/node'
+
+RSpec.describe Lighstorm::Models::Node do
+  context 'error' do
+    it 'raises error' do
+      expect { described_class.adapt }.to raise_error(
+        ArgumentError, 'missing gossip: or dump:'
+      )
+
+      expect { described_class.adapt(gossip: {}, dump: {}) }.to raise_error(
+        TooManyArgumentsError, 'you need to pass gossip: or dump:, not both'
+      )
+    end
+  end
+
+  describe '.apply!' do
+    let(:dump) { symbolize_keys(JSON.parse(File.read("spec/data/gossip/node/#{hash}/dump.json"))) }
+    let(:gossip) { JSON.parse(File.read("spec/data/gossip/node/#{hash}/gossip.json")) }
+
+    context '4dec8c315434' do
+      let(:hash) { '4dec8c315434' }
+
+      it 'provides data portability' do
+        node = described_class.adapt(dump: dump)
+        diff = node.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          [{ path: [:alias], from: 'Gerdtrudroepke', to: 'GerdtrudroepkeA' },
+           { path: [:color], from: '#ff5000', to: '#ff5002' }]
+        )
+      end
+    end
+
+    context 'e0f26f5929be' do
+      let(:hash) { 'e0f26f5929be' }
+
+      it 'provides data portability' do
+        node = described_class.adapt(dump: dump)
+        diff = node.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          [{ path: [:alias], from: 'Gerdtrudroepke', to: 'GerdtrudroepkeA' },
+           { path: [:color], from: '#ff5000', to: '#ff5002' }]
+        )
+      end
+    end
+
+    context 'e957d7ca7573' do
+      let(:hash) { 'e957d7ca7573' }
+
+      it 'provides data portability' do
+        node = described_class.adapt(dump: dump)
+        diff = node.apply!(gossip: gossip)
+
+        expect(diff).to eq(
+          []
+        )
+      end
+    end
+
+    context 'ef0ca4752244' do
+      let(:hash) { 'ef0ca4752244' }
+
+      it 'provides data portability' do
+        node = described_class.adapt(gossip: gossip)
+
+        expect(node.to_h).to eq(
+          { _key: '8b8b460416bc384260ca166233827f361a0c0da7b632c68a2720e08fbe3f528c',
+            public_key: '023c047f51141b345db60fb4bf7a6a863ed9e010fa8eaba0d596322565a6b9a73b',
+            alias: 'GerdtrudroepkeA',
+            color: '#ff5002' }
+        )
+      end
+    end
+  end
+end

--- a/spec/models/nodes/node_spec.rb
+++ b/spec/models/nodes/node_spec.rb
@@ -98,6 +98,18 @@ RSpec.describe Lighstorm::Models::Node do
         end
       end
     end
+
+    context 'non-existent node' do
+      it 'models' do
+        public_key = '02003e8f41444fbddbfce965eaeb45b362b5c1b0e52b16cc249807ba7f78000928'
+
+        expect do
+          data = Lighstorm::Controllers::Node::FindByPublicKey.data(public_key) do |fetch|
+            VCR.replay("Controllers::Node.find_by_public_key/#{public_key}") { fetch.call }
+          end
+        end.to raise_error GRPC::NotFound
+      end
+    end
   end
 
   describe '.all' do

--- a/spec/ports/dsl/channel_spec.rb
+++ b/spec/ports/dsl/channel_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../ports/dsl/lighstorm'
+require_relative '../../../ports/dsl/lighstorm/errors'
+
+RSpec.describe Lighstorm::Channel do
+  context 'adapts' do
+    context 'errors' do
+      it 'raises error' do
+        expect { described_class.adapt(dump: {}, gossip: {}) }.to raise_error(
+          TooManyArgumentsError, 'you need to pass gossip: or dump:, not both'
+        )
+
+        expect { described_class.adapt }.to raise_error(
+          ArgumentError, 'missing gossip: or dump:'
+        )
+      end
+    end
+
+    context 'dump' do
+      let(:data) do
+        symbolize_keys(JSON.parse(File.read('spec/data/gossip/channel/29f0873593ae/dump.json')))
+      end
+
+      it do
+        channel = described_class.adapt(dump: data)
+
+        expect(Contract.for(channel._key)).to eq('String:50+')
+
+        expect(channel.mine?).to be(false)
+
+        expect(Contract.for(channel.id)).to eq('String:11..20')
+
+        expect { channel.opened_at }.to raise_error(NotYourChannelError)
+        expect { channel.up_at }.to raise_error(NotYourChannelError)
+        expect { channel.state }.to raise_error(NotYourChannelError)
+        expect { channel.active? }.to raise_error(NotYourChannelError)
+
+        expect(Contract.for(channel.exposure)).to eq('String:0..10')
+
+        expect(Contract.for(channel.accounting.capacity.milisatoshis)).to eq('Integer:0..10')
+
+        expect { channel.accounting.sent }.to raise_error(NotYourChannelError)
+        expect { channel.accounting.received }.to raise_error(NotYourChannelError)
+        expect { channel.accounting.unsettled }.to raise_error(NotYourChannelError)
+
+        expect(channel.partners.size).to eq(2)
+
+        expect { channel.myself }.to raise_error(NotYourChannelError)
+        expect { channel.partner }.to raise_error(NotYourChannelError)
+
+        expect { channel.partners[0].accounting }.to raise_error(NotYourChannelError)
+        expect(channel.partners[0].node.myself?).to be(false)
+
+        expect(Contract.for(channel.partners[0].node.public_key)).to eq('String:50+')
+
+        expect(Contract.for(channel.partners[0].policy.fee.base.milisatoshis)).to eq('Integer:0..10')
+        expect(Contract.for(channel.partners[0].policy.fee.rate.parts_per_million)).to eq('Integer:0..10')
+        expect(Contract.for(channel.partners[0].policy.htlc.minimum.milisatoshis)).to eq('Integer:0..10')
+        expect(Contract.for(channel.partners[0].policy.htlc.maximum.milisatoshis)).to eq('Integer:0..10')
+
+        expect { channel.partners[1].accounting }.to raise_error(NotYourChannelError)
+        expect(channel.partners[1].node.myself?).to be(false)
+
+        expect(Contract.for(channel.partners[1].node.public_key)).to eq('String:50+')
+
+        expect(Contract.for(channel.partners[1].policy.fee.base.milisatoshis)).to eq('Integer:0..10')
+        expect(Contract.for(channel.partners[1].policy.fee.rate.parts_per_million)).to eq('Integer:0..10')
+        expect(Contract.for(channel.partners[1].policy.htlc.minimum.milisatoshis)).to eq('Integer:0..10')
+        expect(Contract.for(channel.partners[1].policy.htlc.maximum.milisatoshis)).to eq('Integer:0..10')
+
+        expect(Contract.for(channel.to_h)).to eq(
+          { _key: 'String:50+',
+            accounting: { capacity: { milisatoshis: 'Integer:0..10' } },
+            id: 'String:11..20',
+            partners: [
+              { node: {
+                  _key: 'String:50+',
+                  platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                  public_key: 'String:50+'
+                },
+                policy: {
+                  fee: { base: { milisatoshis: 'Integer:0..10' },
+                         rate: { parts_per_million: 'Integer:0..10' } },
+                  htlc: { blocks: { delta: { minimum: 'Integer:0..10' } },
+                          maximum: { milisatoshis: 'Integer:0..10' },
+                          minimum: { milisatoshis: 'Integer:0..10' } }
+                },
+                state: 'String:0..10' },
+              { node: {
+                  _key: 'String:50+',
+                  platform: { blockchain: 'String:0..10', network: 'String:0..10' },
+                  public_key: 'String:50+'
+                },
+                policy: {
+                  fee: { base: { milisatoshis: 'Integer:0..10' },
+                         rate: { parts_per_million: 'Integer:0..10' } },
+                  htlc: { blocks: { delta: { minimum: 'Integer:0..10' } },
+                          maximum: { milisatoshis: 'Integer:0..10' },
+                          minimum: { milisatoshis: 'Integer:0..10' } }
+                },
+                state: 'String:0..10' }
+            ] }
+        )
+      end
+    end
+
+    context 'gossip' do
+      let(:data) do
+        JSON.parse(File.read('spec/data/gossip/channel/29f0873593ae/gossip.json'))
+      end
+
+      it do
+        channel = described_class.adapt(gossip: data)
+
+        expect(Contract.for(channel.to_h)).to eq(
+          { _key: 'String:50+',
+            id: 'String:11..20',
+            partners: [
+              { node: { _key: 'Nil', public_key: 'String:50+' },
+                policy: {
+                  fee: {
+                    rate: { parts_per_million: 'Integer:0..10' }
+                  },
+                  htlc: { blocks: { delta: { minimum: 'Integer:0..10' } },
+                          maximum: { milisatoshis: 'Integer:0..10' },
+                          minimum: { milisatoshis: 'Integer:0..10' } }
+                },
+                state: 'Nil' },
+              { node: {
+                  _key: 'Nil',
+                  public_key: 'String:50+'
+                },
+                state: 'Nil' }
+            ] }
+        )
+      end
+    end
+  end
+end

--- a/spec/ports/dsl/node_spec.rb
+++ b/spec/ports/dsl/node_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../../../ports/dsl/lighstorm'
+require_relative '../../../ports/dsl/lighstorm/errors'
+
+RSpec.describe Lighstorm::Node do
+  context 'adapts' do
+    context 'errors' do
+      it 'raises error' do
+        expect { described_class.adapt(dump: {}, gossip: {}) }.to raise_error(
+          TooManyArgumentsError, 'you need to pass gossip: or dump:, not both'
+        )
+
+        expect { described_class.adapt }.to raise_error(
+          ArgumentError, 'missing gossip: or dump:'
+        )
+      end
+    end
+
+    context 'dump' do
+      let(:data) do
+        symbolize_keys(JSON.parse(File.read('spec/data/gossip/node/4dec8c315434/dump.json')))
+      end
+
+      it do
+        node = described_class.adapt(dump: data)
+
+        expect(Contract.for(node._key)).to eq('String:50+')
+        expect(Contract.for(node.alias)).to eq('String:11..20')
+        expect(Contract.for(node.public_key)).to eq('String:50+')
+        expect(Contract.for(node.color)).to eq('String:0..10')
+        expect(Contract.for(node.myself?)).to be('Boolean')
+
+        expect(Contract.for(node.platform.blockchain)).to eq('String:0..10')
+        expect(Contract.for(node.platform.network)).to eq('String:0..10')
+
+        expect(Contract.for(node.to_h)).to eq(
+          { _key: 'String:50+',
+            alias: 'String:11..20',
+            color: 'String:0..10',
+            platform: {
+              blockchain: 'String:0..10',
+              network: 'String:0..10'
+            },
+            public_key: 'String:50+' }
+        )
+      end
+    end
+
+    context 'gossip' do
+      let(:data) do
+        JSON.parse(File.read('spec/data/gossip/node/4dec8c315434/gossip.json'))
+      end
+
+      it do
+        node = described_class.adapt(gossip: data)
+
+        expect(Contract.for(node._key)).to eq('String:50+')
+        expect(Contract.for(node.alias)).to eq('String:11..20')
+        expect(Contract.for(node.public_key)).to eq('String:50+')
+        expect(Contract.for(node.color)).to eq('String:0..10')
+        expect(Contract.for(node.myself?)).to be('Boolean')
+
+        expect(Contract.for(node.platform.blockchain)).to eq('Nil')
+        expect(Contract.for(node.platform.network)).to eq('Nil')
+
+        expect(Contract.for(node.to_h)).to eq(
+          { _key: 'String:50+',
+            alias: 'String:11..20',
+            color: 'String:0..10',
+            public_key: 'String:50+' }
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,13 +8,26 @@ require_relative './helpers/sanitizer'
 
 def check_integration!(slow: false)
   if ENV.fetch('LIGHSTORM_RUN_INTEGRATION_TESTS') != 'true'
-    skip('integration tests are disabled')
+    skip('integration tests are inactive')
     return
   end
 
   return unless slow && ENV.fetch('LIGHSTORM_RUN_INTEGRATION_TESTS_SLOW') != 'true'
 
-  skip('slow integration tests are disabled')
+  skip('slow integration tests are inactive')
+end
+
+def symbolize_keys(object)
+  case object
+  when Hash
+    object.each_with_object({}) do |(key, value), result|
+      result[key.to_sym] = symbolize_keys(value)
+    end
+  when Array
+    object.map { |e| symbolize_keys(e) }
+  else
+    object
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Adding state for channels and connections:

```ruby
channel.state
channel.active?

channel.partner.state
channel.partner.active?

channel.myself.state
channel.myself.active?
```

Adding data portability for Channels and Nodes.

Now you can dump a Channel or Node and reconstruct it. This is helpful for caching, messaging platforms, backups, etc.
```ruby
dump = channel.dump

channel = Lighstorm::Channel.adapt(dump: dump)

dump = node.dump

node = Lighstorm::Channel.node(dump: dump)
```

Support for the [The Gossip Network](https://docs.lightning.engineering/the-lightning-network/the-gossip-network):
```ruby
diff = channel.apply!(gossip: gossip)
diff = node.apply!(gossip: gossip)

Lighstorm::Channel.adapt(gossip: gossip)
Lighstorm::Node.adapt(gossip: gossip)
```
Helpful for playing with [subscribe_channel_graph](https://icebaker.github.io/lnd-client/#/README?id=subscribe_channel_graph).